### PR TITLE
Make editors take 100% of height

### DIFF
--- a/client/components/Editors/Package/Layout.tsx
+++ b/client/components/Editors/Package/Layout.tsx
@@ -87,8 +87,10 @@ function LayoutWithMenu() {
 
   return (
     <Columns spacing={3} layout={[2, 8]} columns={10}>
-      <Box className="package__box__file-menu"
-        sx={{ padding: 2, borderRight: 'solid 1px #ddd', height: '100%' }}>
+      <Box
+        className="package__box__file-menu"
+        sx={{ padding: 2, borderRight: 'solid 1px #ddd', height: '100%' }}
+      >
         {!shallow && (
           <Box
             sx={{
@@ -113,9 +115,11 @@ function LayoutWithMenu() {
         />
       </Box>
       <Box className="package__box__main-menu">
-        <Box hidden={!section.startsWith('package')}
+        <Box
+          hidden={!section.startsWith('package')}
           className="inner-wrapper"
-          sx={{ height: '100%', display: 'flex' }}>
+          sx={{ height: '100%', display: 'flex' }}
+        >
           <LayoutWithoutMenu />
         </Box>
         {!shallow && (

--- a/client/components/Editors/Package/Layout.tsx
+++ b/client/components/Editors/Package/Layout.tsx
@@ -18,7 +18,7 @@ import * as types from '../../../types'
 
 export default function Layout() {
   return (
-    <Box sx={{ height: '100%' }}>
+    <Box className="package__layout__box" sx={{ height: '100%', display: 'flex' }}>
       <LayoutWithMenu />
     </Box>
   )
@@ -87,7 +87,8 @@ function LayoutWithMenu() {
 
   return (
     <Columns spacing={3} layout={[2, 8]} columns={10}>
-      <Box sx={{ padding: 2, borderRight: 'solid 1px #ddd', height: '100%' }}>
+      <Box className="package__box__file-menu"
+        sx={{ padding: 2, borderRight: 'solid 1px #ddd', height: '100%' }}>
         {!shallow && (
           <Box
             sx={{
@@ -111,8 +112,10 @@ function LayoutWithMenu() {
           }}
         />
       </Box>
-      <Box>
-        <Box hidden={!section.startsWith('package')}>
+      <Box className="package__box__main-menu">
+        <Box hidden={!section.startsWith('package')}
+          className="inner-wrapper"
+          sx={{ height: '100%', display: 'flex' }}>
           <LayoutWithoutMenu />
         </Box>
         {!shallow && (
@@ -156,7 +159,7 @@ function LayoutWithoutMenu() {
   if (!section) return null
   return (
     <Columns spacing={3} layout={[5, 3]} columns={8}>
-      <Box>
+      <Box className="layout-without-menu__box">
         <Box hidden={section !== 'package'}>
           <PackageSection />
         </Box>

--- a/client/components/Parts/Boxes/Scroll.tsx
+++ b/client/components/Parts/Boxes/Scroll.tsx
@@ -8,6 +8,7 @@ export default function ScrollBox(props: React.PropsWithChildren<ScrollBoxProps>
   return (
     <Box
       sx={{
+        display: 'flex',
         height: props.height,
         overflow: 'auto',
         scrollbarWidth: 'thin',

--- a/client/components/Parts/Grids/Columns.tsx
+++ b/client/components/Parts/Grids/Columns.tsx
@@ -17,13 +17,15 @@ export default function Columns(props: React.PropsWithChildren<ColumnsProps>) {
   ) as GridSize
   return (
     <Grid
+      className="columns__grid"
       container
       columns={columns}
       columnSpacing={props.spacing}
       sx={{ height: props.height }}
     >
       {React.Children.map(props.children, (child, index) => (
-        <Grid item key={index} md={props.layout ? props.layout[index] : defaultWidth}>
+        <Grid item key={index} md={props.layout ? props.layout[index] : defaultWidth}
+          sx={{ display: 'flex' }}>
           {child}
         </Grid>
       ))}


### PR DESCRIPTION
These modifications are affecting mainly the Chart and PackageData editors.

- fixes #235 

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
