### PR TITLE
Show desktop app window frame with default window buttons

### DIFF
--- a/desktop/window.ts
+++ b/desktop/window.ts
@@ -12,7 +12,6 @@ export function createWindow() {
     show: false,
     // alwaysOnTop: true,
     autoHideMenuBar: true,
-    titleBarStyle: 'hidden',
     ...(process.platform === 'linux' ? { icon } : {}),
     webPreferences: {
       preload: join(__dirname, 'preload', 'index.js'),


### PR DESCRIPTION
Still in the process of getting my virtual box but I am suspecting the problem lies in titleBarStyle property that was set to 'hidden'.

More info: https://www.electronjs.org/docs/latest/tutorial /window-customization#apply-custom-title-bar-styles-macos-windows

- fixes #275 

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
