### PR TITLE
Add build workflow to upload artifacts.

### DIFF
--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -73,6 +73,7 @@ jobs:
             dist/*.deb
             dist/*.exe
             dist/*.dmg
+          retention-days: 14
 
   # Release
 

--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -36,6 +36,44 @@ jobs:
       - name: Test software
         run: make test
 
+  # Build
+
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    needs: [test]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Prepare environment
+        run: pip3 install hatch
+      - name: Install dependencies
+        run: make install
+      - name: Build software
+        run: make build
+      - name: Dist software
+        run: make dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: distribution-files
+          path: |
+            dist/*.deb
+            dist/*.exe
+            dist/*.dmg
+
   # Release
 
   release:

--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Archive build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: distribution-files
+          name: distribution-files-${{ matrix.os }}
           path: |
             dist/*.deb
             dist/*.exe


### PR DESCRIPTION
This PR adds a build workflow and stores the artifacts in Github Actions. 

This can be handy to easily access the distribution files to test. Without the need to pull, build and dist every PR we want to test.

More info: https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts

## How to test

1. Go the the Actions sections
2. Click on the Action run by the PR (example: https://github.com/okfn/opendataeditor/actions/runs/8815010899)
3. Navigate to the bottom
4. You should be able to download a `.zip` files with the installers.

![image](https://github.com/okfn/opendataeditor/assets/6672339/d39962d5-06ee-4f14-b699-c6bf2a24bb5e)
