### PR TITLE
391 document indexing and table store

### DIFF
--- a/client/components/Controllers/Table/store.ts
+++ b/client/components/Controllers/Table/store.ts
@@ -59,7 +59,7 @@ export interface State {
   onClickAway: () => void
 
   // Editing
-  // The following functions are called when the user edit values in 
+  // The following functions are called when the user edit values in
   // the data grid.
   initialEditingValue?: any
   // TODO: find proper context type

--- a/client/components/Controllers/Table/store.ts
+++ b/client/components/Controllers/Table/store.ts
@@ -14,8 +14,11 @@ import * as helpers from '../../../helpers'
 import * as types from '../../../types'
 
 export interface State {
+  // Path of the file relative to the project
   path: string
+  // Singleton to connect to the backend
   client: Client
+  // Event triggered onSave, it is set as a property of the component
   onSave: () => void
   onSaveAs: (path: string) => void
   mode?: 'errors'
@@ -30,26 +33,34 @@ export interface State {
   updateState: (patch: Partial<State>) => void
 
   // General
-
+  // Set the values required to load the component: data, errors, reports, etc
   load: () => Promise<void>
   loadSource: () => Promise<void>
+  // Edit the table using an AI prompt
   edit: (prompt: string) => Promise<void>
   saveAs: (toPath: string) => Promise<void>
+  // Revert all the changes that were not saved to disk.
   revert: () => void
+  // Save the changes made to the data grid to disk.
   save: () => Promise<void>
   publish: (control: types.IControl) => Promise<string | undefined>
+  // Returns the tabular data indexed in the SQLite database.
+  // It will apply historyChanges if they exist.
   loader: types.ITableLoader
+  // Array of changes that the user made to the data. Kept until saving to disk.
   history: types.IHistory
   undoneHistory: types.IHistory
   selection?: types.ITableSelection
   error?: types.IError
   toggleErrorMode: () => Promise<void>
   gridRef?: React.MutableRefObject<ITableEditor>
+  // Removes all entries from history. Called when reverting all changes.
   clearHistory: () => void
   onClickAway: () => void
 
   // Editing
-
+  // The following functions are called when the user edit values in 
+  // the data grid.
   initialEditingValue?: any
   // TODO: find proper context type
   startEditing: (context: any) => void

--- a/client/components/Controllers/Table/store.ts
+++ b/client/components/Controllers/Table/store.ts
@@ -14,63 +14,62 @@ import * as helpers from '../../../helpers'
 import * as types from '../../../types'
 
 export interface State {
-  // Path of the file relative to the project
+  /** Path of the file relative to the project **/
   path: string
-  // Singleton to connect to the backend
+  /** Singleton to connect to the backend **/
   client: Client
-  // Event triggered onSave, it is set as a property of the component
+  /** Event triggered onSave, it is set as a property of the component **/
   onSave: () => void
-  // Event triggered onSaveAs, it is set as a property of the component
+  /** Event triggered onSaveAs, it is set as a property of the component **/
   onSaveAs: (path: string) => void
-  // Keeps track if we are displaying the full datagrid or only errors.
+  /** Keeps track if we are displaying the full datagrid or only errors. **/
   mode?: 'errors'
-  // Keeps track of the selected panel
+  /** Keeps track of the selected panel **/
   panel?: 'metadata' | 'report' | 'changes' | 'source'
-  // Keeps track of the displayed dialog
+  /** Keeps track of the displayed dialog **/
   dialog?: 'publish' | 'saveAs' | 'chat' | 'leave'
   record?: types.IRecord
   report?: types.IReport
   measure?: types.IMeasure
-  // Stores the content of the raw file when loadSource is triggered.
+  /** Stores the content of the raw file when loadSource is triggered. **/
   source?: string
-  // Number of rows of the file
+  /** Number of rows of the file **/
   rowCount?: number
   resource?: types.IResource
   updateState: (patch: Partial<State>) => void
 
   // General
-  // Set the values required to load the component: data, errors, reports, etc
+  /** Set the values required to load the component: data, errors, reports, etc **/
   load: () => Promise<void>
-  // Loads the source view of the file (Displays raw CSV file)
+  /** Loads the source view of the file (Displays raw CSV file) **/
   loadSource: () => Promise<void>
-  // Edit the table using an AI prompt
+  /** Edit the table using an AI prompt **/
   edit: (prompt: string) => Promise<void>
-  // Save file to another path
+  /** Save file to another path **/
   saveAs: (toPath: string) => Promise<void>
-  // Revert all the changes done to the datagrid that were not saved to disk.
+  /** Revert all the changes done to the datagrid that were not saved to disk. **/
   revert: () => void
-  // Save the changes made to the datagrid to disk.
+  /** Save the changes made to the datagrid to disk. **/
   save: () => Promise<void>
-  // Calls to frictionless-py Publish function.
+  /** Calls to frictionless-py Publish function. **/
   publish: (control: types.IControl) => Promise<string | undefined>
-  // Returns the tabular data indexed in the SQLite database.
-  // It will apply historyChanges if they exist.
+  /** Returns the tabular data indexed in the SQLite database. **/
+  /** It will apply historyChanges if they exist. **/
   loader: types.ITableLoader
-  // Array of changes that the user made to the datagrid. Kept until saving to disk.
+  /** Array of changes that the user made to the datagrid. Kept until saving to disk. **/
   history: types.IHistory
   undoneHistory: types.IHistory
   selection?: types.ITableSelection
-  // Used to display in the table view only rows with errors
+  /** Used to display in the table view only rows with errors **/
   toggleErrorMode: () => Promise<void>
   gridRef?: React.MutableRefObject<ITableEditor>
-  // Removes all entries from history. Called when reverting all changes.
+  /** Removes all entries from history. Called when reverting all changes. **/
   clearHistory: () => void
-  // Handles event when user clicks outside a dialog
+  /** Handles event when user clicks outside a dialog **/
   onClickAway: () => void
 
   // Editing
-  // The following functions are called when the user edit values in
-  // the data grid.
+  /** The following functions are called when the user edit values in the data grid. **/
   initialEditingValue?: any
   // TODO: find proper context type
   startEditing: (context: any) => void

--- a/client/components/Controllers/Table/store.ts
+++ b/client/components/Controllers/Table/store.ts
@@ -20,14 +20,20 @@ export interface State {
   client: Client
   // Event triggered onSave, it is set as a property of the component
   onSave: () => void
+  // Event triggered onSaveAs, it is set as a property of the component
   onSaveAs: (path: string) => void
+  // Keeps track if we are displaying the full datagrid or only errors.
   mode?: 'errors'
+  // Keeps track of the selected panel
   panel?: 'metadata' | 'report' | 'changes' | 'source'
+  // Keeps track of the displayed dialog
   dialog?: 'publish' | 'saveAs' | 'chat' | 'leave'
   record?: types.IRecord
   report?: types.IReport
   measure?: types.IMeasure
+  // Stores the content of the raw file when loadSource is triggered.
   source?: string
+  // Number of rows of the file
   rowCount?: number
   resource?: types.IResource
   updateState: (patch: Partial<State>) => void
@@ -35,27 +41,31 @@ export interface State {
   // General
   // Set the values required to load the component: data, errors, reports, etc
   load: () => Promise<void>
+  // Loads the source view of the file (Displays raw CSV file)
   loadSource: () => Promise<void>
   // Edit the table using an AI prompt
   edit: (prompt: string) => Promise<void>
+  // Save file to another path
   saveAs: (toPath: string) => Promise<void>
-  // Revert all the changes that were not saved to disk.
+  // Revert all the changes done to the datagrid that were not saved to disk.
   revert: () => void
-  // Save the changes made to the data grid to disk.
+  // Save the changes made to the datagrid to disk.
   save: () => Promise<void>
+  // Calls to frictionless-py Publish function.
   publish: (control: types.IControl) => Promise<string | undefined>
   // Returns the tabular data indexed in the SQLite database.
   // It will apply historyChanges if they exist.
   loader: types.ITableLoader
-  // Array of changes that the user made to the data. Kept until saving to disk.
+  // Array of changes that the user made to the datagrid. Kept until saving to disk.
   history: types.IHistory
   undoneHistory: types.IHistory
   selection?: types.ITableSelection
-  error?: types.IError
+  // Used to display in the table view only rows with errors
   toggleErrorMode: () => Promise<void>
   gridRef?: React.MutableRefObject<ITableEditor>
   // Removes all entries from history. Called when reverting all changes.
   clearHistory: () => void
+  // Handles event when user clicks outside a dialog
   onClickAway: () => void
 
   // Editing


### PR DESCRIPTION
Fixes #391 

This PR is part of understanding and documenting the indexing flow of tabular data.

@roll and @guergana  I'm proposing this idea to start documenting what are the properties and when are they used. I think will improve a lot the readability of the codebase.

I couldn't find any reference nor use of the ` error?: types.IError` property. @roll correct me if I'm wrong.