### PR TITLE
Cleanup unnecessary ThemeProviders

### DIFF
--- a/client/components/Editors/Chart/index.tsx
+++ b/client/components/Editors/Chart/index.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
 import { StoreProvider, makeStore } from './store'
-import { ThemeProvider } from '@mui/material/styles'
-import * as themes from '../../../themes'
 import * as types from '../../../types'
 import Layout from './Layout'
 
@@ -14,10 +12,8 @@ export interface ChartProps {
 export default function Chart(props: ChartProps) {
   const store = React.useMemo(() => makeStore(props), Object.values(props))
   return (
-    <ThemeProvider theme={themes.DEFAULT}>
       <StoreProvider value={store}>
         <Layout />
       </StoreProvider>
-    </ThemeProvider>
   )
 }

--- a/client/components/Editors/Chart/index.tsx
+++ b/client/components/Editors/Chart/index.tsx
@@ -12,8 +12,8 @@ export interface ChartProps {
 export default function Chart(props: ChartProps) {
   const store = React.useMemo(() => makeStore(props), Object.values(props))
   return (
-      <StoreProvider value={store}>
-        <Layout />
-      </StoreProvider>
+    <StoreProvider value={store}>
+      <Layout />
+    </StoreProvider>
   )
 }

--- a/client/components/Editors/Config/index.tsx
+++ b/client/components/Editors/Config/index.tsx
@@ -12,8 +12,8 @@ export interface ConfigProps {
 export default function Config(props: ConfigProps) {
   const store = React.useMemo(() => makeStore(props), Object.values(props))
   return (
-      <StoreProvider value={store}>
-        <Layout />
-      </StoreProvider>
+    <StoreProvider value={store}>
+      <Layout />
+    </StoreProvider>
   )
 }

--- a/client/components/Editors/Config/index.tsx
+++ b/client/components/Editors/Config/index.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
-import * as themes from '../../../themes'
 import { StoreProvider, makeStore } from './store'
-import { ThemeProvider } from '@mui/material/styles'
 import Layout from './Layout'
 import * as types from '../../../types'
 
@@ -14,10 +12,8 @@ export interface ConfigProps {
 export default function Config(props: ConfigProps) {
   const store = React.useMemo(() => makeStore(props), Object.values(props))
   return (
-    <ThemeProvider theme={themes.DEFAULT}>
       <StoreProvider value={store}>
         <Layout />
       </StoreProvider>
-    </ThemeProvider>
   )
 }

--- a/client/components/Editors/Dialect/index.tsx
+++ b/client/components/Editors/Dialect/index.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
 import { StoreProvider, makeStore } from './store'
-import { ThemeProvider } from '@mui/material/styles'
-import * as themes from '../../../themes'
 import * as types from '../../../types'
 import Layout from './Layout'
 
@@ -15,10 +13,8 @@ export interface DialectProps {
 export default function Dialect(props: DialectProps) {
   const store = React.useMemo(() => makeStore(props), Object.values(props))
   return (
-    <ThemeProvider theme={themes.DEFAULT}>
       <StoreProvider value={store}>
         <Layout />
       </StoreProvider>
-    </ThemeProvider>
   )
 }

--- a/client/components/Editors/Dialect/index.tsx
+++ b/client/components/Editors/Dialect/index.tsx
@@ -13,8 +13,8 @@ export interface DialectProps {
 export default function Dialect(props: DialectProps) {
   const store = React.useMemo(() => makeStore(props), Object.values(props))
   return (
-      <StoreProvider value={store}>
-        <Layout />
-      </StoreProvider>
+    <StoreProvider value={store}>
+      <Layout />
+    </StoreProvider>
   )
 }

--- a/client/components/Editors/Package/index.tsx
+++ b/client/components/Editors/Package/index.tsx
@@ -14,8 +14,8 @@ export interface PackageProps {
 export default function Package(props: PackageProps) {
   const store = React.useMemo(() => makeStore(props), Object.values(props))
   return (
-      <StoreProvider value={store}>
-        <Layout />
-      </StoreProvider>
+    <StoreProvider value={store}>
+      <Layout />
+    </StoreProvider>
   )
 }

--- a/client/components/Editors/Package/index.tsx
+++ b/client/components/Editors/Package/index.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
 import { StoreProvider, makeStore } from './store'
-import { ThemeProvider } from '@mui/material/styles'
-import * as themes from '../../../themes'
 import * as types from '../../../types'
 import Layout from './Layout'
 
@@ -16,10 +14,8 @@ export interface PackageProps {
 export default function Package(props: PackageProps) {
   const store = React.useMemo(() => makeStore(props), Object.values(props))
   return (
-    <ThemeProvider theme={themes.DEFAULT}>
       <StoreProvider value={store}>
         <Layout />
       </StoreProvider>
-    </ThemeProvider>
   )
 }

--- a/client/components/Editors/Portal/index.tsx
+++ b/client/components/Editors/Portal/index.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
-import * as themes from '../../../themes'
 import { StoreProvider, makeStore } from './store'
-import { ThemeProvider } from '@mui/material/styles'
 import Layout from './Layout'
 import * as types from '../../../types'
 
@@ -13,10 +11,8 @@ export interface PortalProps {
 export default function Portal(props: PortalProps) {
   const store = React.useMemo(() => makeStore(props), Object.values(props))
   return (
-    <ThemeProvider theme={themes.DEFAULT}>
       <StoreProvider value={store}>
         <Layout />
       </StoreProvider>
-    </ThemeProvider>
   )
 }

--- a/client/components/Editors/Portal/index.tsx
+++ b/client/components/Editors/Portal/index.tsx
@@ -11,8 +11,8 @@ export interface PortalProps {
 export default function Portal(props: PortalProps) {
   const store = React.useMemo(() => makeStore(props), Object.values(props))
   return (
-      <StoreProvider value={store}>
-        <Layout />
-      </StoreProvider>
+    <StoreProvider value={store}>
+      <Layout />
+    </StoreProvider>
   )
 }

--- a/client/components/Editors/Resource/index.tsx
+++ b/client/components/Editors/Resource/index.tsx
@@ -14,8 +14,8 @@ export interface ResourceProps {
 export default function Resource(props: ResourceProps) {
   const store = React.useMemo(() => makeStore(props), Object.values(props))
   return (
-      <StoreProvider value={store}>
-        <Layout />
-      </StoreProvider>
+    <StoreProvider value={store}>
+      <Layout />
+    </StoreProvider>
   )
 }

--- a/client/components/Editors/Resource/index.tsx
+++ b/client/components/Editors/Resource/index.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
 import { StoreProvider, makeStore } from './store'
-import { ThemeProvider } from '@mui/material/styles'
-import * as themes from '../../../themes'
 import * as types from '../../../types'
 import Layout from './Layout'
 
@@ -16,10 +14,8 @@ export interface ResourceProps {
 export default function Resource(props: ResourceProps) {
   const store = React.useMemo(() => makeStore(props), Object.values(props))
   return (
-    <ThemeProvider theme={themes.DEFAULT}>
       <StoreProvider value={store}>
         <Layout />
       </StoreProvider>
-    </ThemeProvider>
   )
 }

--- a/client/components/Editors/Schema/index.tsx
+++ b/client/components/Editors/Schema/index.tsx
@@ -13,8 +13,8 @@ export interface SchemaProps {
 export default function Schema(props: SchemaProps) {
   const store = React.useMemo(() => makeStore(props), Object.values(props))
   return (
-      <StoreProvider value={store}>
-        <Layout />
-      </StoreProvider>
+    <StoreProvider value={store}>
+      <Layout />
+    </StoreProvider>
   )
 }

--- a/client/components/Editors/Schema/index.tsx
+++ b/client/components/Editors/Schema/index.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react'
 import { StoreProvider, makeStore } from './store'
-import { ThemeProvider } from '@mui/material/styles'
 import Layout from './Layout'
-import * as themes from '../../../themes'
 import * as types from '../../../types'
 
 export interface SchemaProps {
@@ -15,10 +13,8 @@ export interface SchemaProps {
 export default function Schema(props: SchemaProps) {
   const store = React.useMemo(() => makeStore(props), Object.values(props))
   return (
-    <ThemeProvider theme={themes.DEFAULT}>
       <StoreProvider value={store}>
         <Layout />
       </StoreProvider>
-    </ThemeProvider>
   )
 }

--- a/client/components/Editors/View/index.tsx
+++ b/client/components/Editors/View/index.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react'
-import * as themes from '../../../themes'
 import { ITextEditor } from '../Text'
 import { StoreProvider, makeStore } from './store'
-import { ThemeProvider } from '@mui/material/styles'
 import Layout from './Layout'
 import * as types from '../../../types'
 
@@ -16,10 +14,8 @@ export default function View(props: ViewProps) {
   const editorRef = React.useMemo(() => React.createRef<ITextEditor>(), [])
   const store = React.useMemo(() => makeStore(props, editorRef), Object.values(props))
   return (
-    <ThemeProvider theme={themes.DEFAULT}>
       <StoreProvider value={store}>
         <Layout />
       </StoreProvider>
-    </ThemeProvider>
   )
 }

--- a/client/components/Editors/View/index.tsx
+++ b/client/components/Editors/View/index.tsx
@@ -14,8 +14,8 @@ export default function View(props: ViewProps) {
   const editorRef = React.useMemo(() => React.createRef<ITextEditor>(), [])
   const store = React.useMemo(() => makeStore(props, editorRef), Object.values(props))
   return (
-      <StoreProvider value={store}>
-        <Layout />
-      </StoreProvider>
+    <StoreProvider value={store}>
+      <Layout />
+    </StoreProvider>
   )
 }

--- a/client/components/Views/Report/index.tsx
+++ b/client/components/Views/Report/index.tsx
@@ -1,8 +1,6 @@
 import './assets/styles.css'
 import Box from '@mui/material/Box'
 import ReportTask from './Task'
-import { ThemeProvider } from '@mui/material/styles'
-import * as themes from '../../../themes'
 import * as types from '../../../types'
 
 export interface ReportProps {
@@ -12,12 +10,10 @@ export interface ReportProps {
 
 export default function Report(props: ReportProps) {
   return (
-    <ThemeProvider theme={themes.DEFAULT}>
       <div className="frictionless-components-report">
         <TopLevelErrors {...props} />
         {props.shallow ? <ShallowTasks {...props} /> : <ExpandedTasks {...props} />}
       </div>
-    </ThemeProvider>
   )
 }
 

--- a/client/components/Views/Report/index.tsx
+++ b/client/components/Views/Report/index.tsx
@@ -10,10 +10,10 @@ export interface ReportProps {
 
 export default function Report(props: ReportProps) {
   return (
-      <div className="frictionless-components-report">
-        <TopLevelErrors {...props} />
-        {props.shallow ? <ShallowTasks {...props} /> : <ExpandedTasks {...props} />}
-      </div>
+    <div className="frictionless-components-report">
+      <TopLevelErrors {...props} />
+      {props.shallow ? <ShallowTasks {...props} /> : <ExpandedTasks {...props} />}
+    </div>
   )
 }
 


### PR DESCRIPTION
This is a continuation of https://github.com/okfn/opendataeditor/pull/376

Now only one ThemeProvider call remains, and it is at the top of the application component.