### PR TITLE
Proof of Concept - testing Desktop menu options

### DIFF
--- a/desktop/index.ts
+++ b/desktop/index.ts
@@ -1,4 +1,4 @@
-import { app, dialog, BrowserWindow } from 'electron'
+import { app, dialog, BrowserWindow, Menu } from 'electron'
 import { electronApp, optimizer } from '@electron-toolkit/utils'
 import { createWindow } from './window'
 import { createBridge } from './bridge'
@@ -10,6 +10,7 @@ import * as server from './server'
 import * as python from './python'
 import * as settings from './settings'
 import * as resources from './resources'
+const { mainMenu } = require('./menu.ts')
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
@@ -69,3 +70,5 @@ process.on('unhandledRejection', async (error: any) => {
 
 // Configure logger to write to the app directory
 log.transports.file.resolvePath = () => join(settings.APP_HOME, 'logger', 'main.log')
+
+Menu.setApplicationMenu(mainMenu)

--- a/desktop/index.ts
+++ b/desktop/index.ts
@@ -10,7 +10,8 @@ import * as server from './server'
 import * as python from './python'
 import * as settings from './settings'
 import * as resources from './resources'
-const { mainMenu } = require('./menu.ts')
+// const { mainMenu } = require('./menu.ts')
+import mainMenu from './menu'
 
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.

--- a/desktop/index.ts
+++ b/desktop/index.ts
@@ -10,7 +10,6 @@ import * as server from './server'
 import * as python from './python'
 import * as settings from './settings'
 import * as resources from './resources'
-// const { mainMenu } = require('./menu.ts')
 import mainMenu from './menu'
 
 // This method will be called when Electron has finished

--- a/desktop/menu.ts
+++ b/desktop/menu.ts
@@ -72,4 +72,6 @@ const template = [
   },
 ]
 
-module.exports.mainMenu = Menu.buildFromTemplate(template)
+// module.exports.mainMenu = Menu.buildFromTemplate(template)
+
+export default Menu.buildFromTemplate(template)

--- a/desktop/menu.ts
+++ b/desktop/menu.ts
@@ -1,0 +1,75 @@
+import { app, Menu, MenuItemConstructorOptions } from 'electron'
+
+const isMac = process.platform === 'darwin'
+
+const template = [
+    ...(isMac ? [{
+        label: app.name,
+        submenu: [
+            { role: 'about' },
+            { type: 'separator' },
+            { type: 'separator' },
+            { role: 'quit' }
+        ]
+    }]: []) as MenuItemConstructorOptions[],
+    // { role: fileMenu }
+    {
+        label: 'Fileyooo',
+        submenu: [
+            {
+                label: 'Open file',
+                click: async () => {
+                    //doOpenFile()
+                }
+            }
+        ] as MenuItemConstructorOptions[]
+    },
+    // { role: 'editMenu' }
+  {
+    label: 'Edituuuu',
+    submenu: [
+      { role: 'undo' },
+      { role: 'redo' },
+      { type: 'separator' },
+      { role: 'cut' },
+      { role: 'copy' },
+      { role: 'paste' },
+      ...(isMac
+        ? [
+            { role: 'pasteAndMatchStyle' },
+            { role: 'delete' },
+            { role: 'selectAll' },
+            { type: 'separator' },
+            {
+              label: 'Speech',
+              submenu: [
+                { role: 'startSpeaking' },
+                { role: 'stopSpeaking' }
+              ]
+            }
+          ]
+        : [
+            { role: 'delete' },
+            { type: 'separator' },
+            { role: 'selectAll' }
+          ])
+    ] as MenuItemConstructorOptions[]
+  },
+  // { role: 'viewMenu' }
+  {
+    label: 'View',
+    submenu: [
+      { role: 'reload' },
+      { role: 'forceReload' },
+      { role: 'toggleDevTools' },
+      { type: 'separator' },
+      { role: 'resetZoom' },
+      { role: 'zoomIn' },
+      { role: 'zoomOut' },
+      { type: 'separator' },
+      { role: 'togglefullscreen' }
+    ] as MenuItemConstructorOptions[]
+  },
+]
+
+module.exports.mainMenu = Menu.buildFromTemplate(template)

--- a/desktop/window.ts
+++ b/desktop/window.ts
@@ -11,7 +11,7 @@ export function createWindow() {
     // height: 670,
     show: false,
     // alwaysOnTop: true,
-    autoHideMenuBar: true,
+    // autoHideMenuBar: true,
     ...(process.platform === 'linux' ? { icon } : {}),
     webPreferences: {
       preload: join(__dirname, 'preload', 'index.js'),


### PR DESCRIPTION
- fixes #392 

This PR is for testing out how customizable the desktop app menu is for different platforms. Not to be merged.

Findings:
- The Menu is highly customizable. 
- There are generic menu functions defined as roles.
- The actions on the submenus can be also functions that do specific tasks within the application
- The nav bar can be hidden by default or show all the time.
- The menu can be rendered differently for MacOS.

