### PR TITLE
Hide lock/unlock and group/ungroup functions from context menu

### DIFF
--- a/client/components/Editors/Table/index.tsx
+++ b/client/components/Editors/Table/index.tsx
@@ -66,6 +66,8 @@ export default function TableEditor(props: TableEditorProps) {
       limit={rowsPerPage}
       onLimitChange={setRowsPerPage}
       rowHeight={rowHeight}
+      showColumnMenuLockOptions={false}
+      showColumnMenuGroupOptions={false}
       {...others}
     />
   )


### PR DESCRIPTION
- fixes #411 

