### PR TITLE
Change the position of the column context menu to show all columns

### DIFF
--- a/client/components/Editors/Table/index.tsx
+++ b/client/components/Editors/Table/index.tsx
@@ -68,6 +68,8 @@ export default function TableEditor(props: TableEditorProps) {
       rowHeight={rowHeight}
       showColumnMenuLockOptions={false}
       showColumnMenuGroupOptions={false}
+      columnContextMenuConstrainTo={true}
+      columnContextMenuPosition={'fixed'}
       {...others}
     />
   )


### PR DESCRIPTION
- fixes #425 

The issue is fixed here, however, the columns are displayed all the way to the top of the application. I have created [an issue in the reactdatagrid repo](https://github.com/inovua/reactdatagrid/issues/421) to address this topic.