### PR TITLE
Close dropdown menu after adding files or folders

### DIFF
--- a/client/components/Application/Buttons/Add.tsx
+++ b/client/components/Application/Buttons/Add.tsx
@@ -10,11 +10,13 @@ import UploadFileRounded from '@mui/icons-material/UploadFileRounded'
 import { useStore } from '../store'
 
 export default function AddButton() {
+  const fileEvent = useStore((state) => state.fileEvent)
   return (
     <DropdownButton
       label="Add"
       variant="text"
       icon={<AddBoxIcon fontSize="small" sx={{ mr: 1 }} />}
+      complete={fileEvent ? false : true}
     >
       <AddLocalFileButton />
       <AddRemoteFileButton />


### PR DESCRIPTION
- fixes #423 

Making use the unused 'complete' prop fixes the issue.