### PR TITLE
Fix missing token for E2E Workflow

### DIFF
--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -60,6 +60,8 @@ jobs:
           run: make build
         - name: Generate bundle file
           run: make dist
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         - name: Make AppImage executable
           run: |
             chmod a+x ./dist/*.AppImage

--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -80,7 +80,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    needs: [test]
+    needs: [test, test-e2e]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -120,7 +120,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    needs: [test]
+    needs: [test, test-e2e]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Currently E2E workflow running on master is failing due to missing Github Token: https://github.com/okfn/opendataeditor/actions/runs/10351212921/job/28649240460

```
Error: GitHub Personal Access Token is not set, neither programmatically, nor using env "GH_TOKEN"
    at new GitHubPublisher (/home/runner/work/opendataeditor/opendataeditor/node_modules/electron-publish/src/gitHubPublisher.ts:52:15)
    at createPublisher (/home/runner/work/opendataeditor/opendataeditor/node_modules/app-builder-lib/src/publish/PublishManager.ts:303:14)
    at PublishManager.getOrCreatePublisher (/home/runner/work/opendataeditor/opendataeditor/node_modules/app-builder-lib/src/publish/PublishManager.ts:222:19)
    at PublishManager.scheduleUpload (/home/runner/work/opendataeditor/opendataeditor/node_modules/app-builder-lib/src/publish/PublishManager.ts:152:28)
    at PublishManager.artifactCreatedWithoutExplicitPublishConfig (/home/runner/work/opendataeditor/opendataeditor/node_modules/app-builder-lib/src/publish/PublishManager.ts:202:14)
    at throwError (/home/runner/work/opendataeditor/opendataeditor/node_modules/builder-util/src/asyncTaskManager.ts:89:11)
    at checkErrors (/home/runner/work/opendataeditor/opendataeditor/node_modules/builder-util/src/asyncTaskManager.ts:53:9)
    at AsyncTaskManager.awaitTasks (/home/runner/work/opendataeditor/opendataeditor/node_modules/builder-util/src/asyncTaskManager.ts:58:5)
    at PublishManager.awaitTasks (/home/runner/work/opendataeditor/opendataeditor/node_modules/app-builder-lib/src/publish/PublishManager.ts:236:28)
    at /home/runner/work/opendataeditor/opendataeditor/node_modules/app-builder-lib/src/index.ts:119:32
    at executeFinally (/home/runner/work/opendataeditor/opendataeditor/node_modules/builder-util/src/promise.ts:23:9)
```

This PR implements:
 - Adds the missing token
 - Adds E2E test as dependency of build steps 
