### PR TITLE
Add a test for a basic CSV file upload

### DIFF
--- a/test/data/valid.csv
+++ b/test/data/valid.csv
@@ -1,0 +1,4 @@
+col_1, col_2
+Ford, 1
+Mercedes, 2
+Renault, 3


### PR DESCRIPTION
This PR implements a small E2E test case that uploads a CSV and check that it is displayed correctly (File Navigator, Editor and Validation Chip).

I'm writing a lot of verbose comments to document some behaviors of the WebdriverIO library that I'm not sure are happening because I'm not using it correcly, because it is a buggy behaviour, or because there is something smelly in our React components.

I guess that in time we are going to understand WebdriverIO better.

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
