### PR TITLE
Hide Chat AI button

### DIFF
--- a/client/components/Controllers/File/Menu.tsx
+++ b/client/components/Controllers/File/Menu.tsx
@@ -21,7 +21,6 @@ export default function Menu() {
         disabled={!source?.text}
         onClick={() => store.togglePanel('report')}
       />
-      <menu.ChatButton disabled />
     </menu.MenuBar>
   )
 }

--- a/client/components/Controllers/Table/Menu.tsx
+++ b/client/components/Controllers/Table/Menu.tsx
@@ -25,7 +25,6 @@ export default function Menu() {
         active={panel === 'source'}
         onClick={() => store.togglePanel('source')}
       />
-      <menu.ChatButton disabled />
       <menu.ErrorsButton
         active={mode === 'errors'}
         onClick={store.toggleTableErrorMode}

--- a/client/components/Controllers/Text/Menu.tsx
+++ b/client/components/Controllers/Text/Menu.tsx
@@ -23,7 +23,6 @@ export default function Menu() {
         onClick={() => store.togglePanel('report')}
       />
       <menu.SourceButton enabled />
-      <menu.ChatButton disabled />
       <menu.UndoButton
         onClick={store.undoText}
         disabled={currentVersion <= minimalVersion}


### PR DESCRIPTION
Only hiding the button from the menu, not deleting the component because we will again work on this after the pre-release. We only need to hide it temporarily

- fixes #502 