### PR TITLE
Fix main screen layout issue.

### DIFF
--- a/client/components/Application/Browser.tsx
+++ b/client/components/Application/Browser.tsx
@@ -39,7 +39,7 @@ function DefaultBrowser() {
     >
       <Button
         color="OKFNCoolGray"
-        sx={{ textTransform: 'none', marginLeft: '16px', marginRight: '16px' }}
+        sx={{ textTransform: 'none', marginLeft: '20px', justifyContent: 'flex-start' }}
         startIcon={<img src={createFolderIcon} alt="" />}
         onClick={() => store.openDialog('addEmptyFolder')}
       >

--- a/client/components/Application/Layout.tsx
+++ b/client/components/Application/Layout.tsx
@@ -15,7 +15,7 @@ export default function Layout() {
     <React.Fragment>
       <Error />
       <Dialog />
-      <Box sx={{ display: 'grid', gridTemplateColumns: '284px 1fr'}}>
+      <Box sx={{ display: 'grid', gridTemplateColumns: '284px 1fr' }}>
         <Sidebar />
         <Content />
       </Box>

--- a/client/components/Application/Layout.tsx
+++ b/client/components/Application/Layout.tsx
@@ -15,7 +15,7 @@ export default function Layout() {
     <React.Fragment>
       <Error />
       <Dialog />
-      <Box sx={{ display: 'grid', gridTemplateColumns: '284px 1fr', height: '100vh' }}>
+      <Box sx={{ display: 'grid', gridTemplateColumns: '284px 1fr'}}>
         <Sidebar />
         <Content />
       </Box>

--- a/client/components/Application/Layout.tsx
+++ b/client/components/Application/Layout.tsx
@@ -15,7 +15,7 @@ export default function Layout() {
     <React.Fragment>
       <Error />
       <Dialog />
-      <Box sx={{ display: 'flex', flexDirection: 'row', height: '100vh' }}>
+      <Box sx={{ display: 'grid', gridTemplateColumns: '284px 1fr', height: '100vh' }}>
         <Sidebar />
         <Content />
       </Box>

--- a/client/components/Application/LowerMenu.tsx
+++ b/client/components/Application/LowerMenu.tsx
@@ -12,9 +12,7 @@ export default function LowerMenu() {
         alignItems: 'flex-start',
         borderTop: '1px solid #E6E7EB',
         padding: '20px',
-        position: 'absolute',
         bottom: 0,
-        width: '100%',
       }}
     >
       <Button

--- a/client/components/Application/Sidebar.tsx
+++ b/client/components/Application/Sidebar.tsx
@@ -1,24 +1,19 @@
 import Box from '@mui/material/Box'
 import Browser from './Browser'
 import LowerMenu from './LowerMenu'
-import { useTheme } from '@mui/material/styles'
 import sidebarLogo from '../../assets/ODE_sidebar_logo.svg'
 import Button from '@mui/material/Button'
 import * as store from '@client/store'
 
 export default function Sidebar() {
-  const theme = useTheme()
-  const contentHeight = `calc(100vh - ${theme.spacing(8 + 8 + 8)})`
 
   return (
     <Box
       className="sidebar"
       sx={{
         display: 'flex',
-        position: 'relative',
         flexDirection: 'column',
         borderRight: 'solid 1px #ddd',
-        width: '284px',
       }}
     >
       <Box sx={{ padding: '24px' }}>
@@ -32,9 +27,7 @@ export default function Sidebar() {
       >
         Upload your data
       </Button>
-      <Box sx={{ height: contentHeight }}>
-        <Browser />
-      </Box>
+      <Browser />
       <LowerMenu />
     </Box>
   )

--- a/client/components/Application/Sidebar.tsx
+++ b/client/components/Application/Sidebar.tsx
@@ -6,7 +6,6 @@ import Button from '@mui/material/Button'
 import * as store from '@client/store'
 
 export default function Sidebar() {
-
   return (
     <Box
       className="sidebar"


### PR DESCRIPTION
This PR fixes a current issue with our layout.

I'm migrating from `flex` (which is designed to let the content guide the layout) to `grid` (which is designed to have a fixed layout).

We are always going to have the same layout, so both `sidebar` and `content` dimensions should **not depend** on it's contents but rather be fixed. Therefore, `grid` makes more sense.

### Current Issue:
![Screenshot_2024-08-27_10-49-53](https://github.com/user-attachments/assets/62ea197e-6274-406c-b8d9-de1aca745a9c)


### PR Solution:
![image](https://github.com/user-attachments/assets/4789aea1-0dda-4836-808a-7ce4b23ea857)

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
