### PR TITLE
Fix issue when toogling folders

### DIFF
--- a/client/components/Parts/Trees/File.tsx
+++ b/client/components/Parts/Trees/File.tsx
@@ -45,10 +45,6 @@ export default function FileTree(props: FileTreeProps) {
             expanded={expanded}
             onNodeSelect={(_event, nodeIds) => props.onSelect(nodeIds)}
             onNodeToggle={(_event: React.SyntheticEvent, nodeIds: string[]) => {
-              // On collapsing we don't collapse a folder if it's not yet selected
-              const isCollapsing = nodeIds.length < expanded.length
-              if (isCollapsing && !expanded.every((value) => selected.includes(value)))
-                return
               setExpanded(nodeIds)
             }}
             defaultCollapseIcon={<img src={openFolderIcon} alt="" />}


### PR DESCRIPTION
- fixes #524 

I'm simplifying the toggle logic. The native one works just fine.

[simplescreenrecorder-2024-08-30_14.19.38.webm](https://github.com/user-attachments/assets/403ec5e7-9c04-4098-98d8-f1cf1d69551a)


---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
