### PR TITLE
348 do not cast values when editing the Grid

### DIFF
--- a/client/store/actions/table.ts
+++ b/client/store/actions/table.ts
@@ -178,7 +178,7 @@ export function saveTableEditing(context: any) {
 
   const rowNumber = context.rowId
   const fieldName = context.columnId
-  if (context.cellProps.type === 'number') value = parseInt(value)
+
   const change: types.IChange = {
     type: 'cell-update',
     rowNumber,

--- a/client/store/actions/table.ts
+++ b/client/store/actions/table.ts
@@ -173,7 +173,7 @@ export function saveTableEditing(context: any) {
   if (!table || !grid) return
 
   // Don't save if not changed
-  let value = context.value
+  const value = context.value
   if (value === table.initialEditingValue) return
 
   const rowNumber = context.rowId


### PR DESCRIPTION
This is a tiny step towards making the experience of editing a little bit more intuitive.

Currently, we have this isolated line of code that forces the user input to be converted to an integer if the cell is "number". This causes the famous `NaN` that confused some users.

I'm removing this from the front-end to move towards a more freely experience of editing the data.

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
