### PR TITLE
Show empty row tooltip

### DIFF
--- a/client/components/Editors/Table/columns.tsx
+++ b/client/components/Editors/Table/columns.tsx
@@ -50,7 +50,7 @@ export function createColumns(
       if (firstError) {
         return (
           <LightTooltip title={firstError.message}>
-            <Box sx={{ width: '80%', minHeight: '20px' }}>{label}</Box>
+            <Box sx={{ minWidth: '80%', minHeight: '20px' }}>{label}</Box>
           </LightTooltip>
         )
       }
@@ -101,7 +101,7 @@ export function createColumns(
         cellProps.style.background = colorPalette.OKFNRed400.main
         value = (
           <LightTooltip title={error.message}>
-            <Box>{value}</Box>
+            <Box sx={{ minWidth: '80%', minHeight: '20px' }}>{value}</Box>
           </LightTooltip>
         )
       }

--- a/client/components/Editors/Table/columns.tsx
+++ b/client/components/Editors/Table/columns.tsx
@@ -1,4 +1,5 @@
 import LightTooltip from '../../Parts/Tooltips/Light'
+import Box from '@mui/material/Box'
 import type { TypeColumn } from '@inovua/reactdatagrid-community/types'
 import * as helpers from '../../../helpers'
 import * as types from '../../../types'
@@ -40,74 +41,85 @@ export function createColumns(
   const dataColumns: IColumn[] = []
   const dataFields = getDataFields({ schema, report })
   for (const field of dataFields) {
-    let header = field.title ?? field.name
-    const errors = errorIndex.label[field.name]
-    if (errors) {
-      const error = errors[0]
-      // @ts-ignore
-      if (error) header = error.label
+    const labelErrors = errorIndex.label[field.name]
+
+    const renderHeader: IColumn['header'] = () => {
+      const firstError = labelErrors?.[0]
+      const label = firstError ? firstError.label : field.title ?? field.name
+
+      if (firstError) {
+        return (
+          <LightTooltip title={firstError.message}>
+            <Box sx={{ width: '80%', minHeight: '20px' }}>{label}</Box>
+          </LightTooltip>
+        )
+      }
+
+      return label
     }
+
+    const renderRow: IColumn['render'] = (context) => {
+      const { cellProps, data } = context
+      let { value } = context
+      const rowNumber = data._rowNumber
+      const columnName = cellProps.id
+      const rowKey = `${rowNumber}`
+      const cellKey = `${rowNumber},${columnName}`
+
+      // Selection
+      if (selection) {
+        if (rowNumber === selection.rowNumber || columnName === selection.columnName) {
+          cellProps.style.color = '#ed6c02'
+        }
+      }
+
+      // Changes
+      let change: types.IChange | undefined
+      if (rowKey in changeIndex.row) {
+        change = changeIndex.row[rowKey]
+      } else if (cellKey in changeIndex.cell) {
+        change = changeIndex.cell[cellKey]
+      }
+      if (change) {
+        cellProps.style.color = 'black'
+        cellProps.style.border = '1px solid ' + colorPalette.OKFNBlue.main
+        cellProps.style.backgroundColor = colorPalette.OKFNGray100.main
+        return value
+      }
+
+      // Errors
+      let error: types.IError | undefined
+      if (rowKey in errorIndex.row) {
+        error = errorIndex.row[rowKey][0]
+      } else if (cellKey in errorIndex.cell) {
+        error = errorIndex.cell[cellKey][0]
+      }
+      if (error) {
+        value = error.cell || value
+        cellProps.style.color = 'white'
+        cellProps.style.cursor = 'pointer'
+        cellProps.style.background = colorPalette.OKFNRed400.main
+        value = (
+          <LightTooltip title={error.message}>
+            <Box>{value}</Box>
+          </LightTooltip>
+        )
+      }
+
+      return value
+    }
+
     dataColumns.push({
       name: field.name,
-      header,
+      header: renderHeader,
       type: ['integer', 'number'].includes(field.type) ? 'number' : 'string',
       editable: !field.isExtra,
-      headerProps:
-        field.name in errorIndex.label
-          ? { style: { color: 'white', background: colorPalette.OKFNRed400.main } }
-          : field.name === selection?.columnName
-          ? { style: { color: '#ed6c02' } }
-          : undefined,
-      render: (context) => {
-        const { cellProps, data } = context
-        let { value } = context
-        const rowNumber = data._rowNumber
-        const columnName = cellProps.id
-        const rowKey = `${rowNumber}`
-        const cellKey = `${rowNumber},${columnName}`
-
-        // Selection
-        if (selection) {
-          if (rowNumber === selection.rowNumber || columnName === selection.columnName) {
-            cellProps.style.color = '#ed6c02'
-          }
-        }
-
-        // Changes
-        let change: types.IChange | undefined
-        if (rowKey in changeIndex.row) {
-          change = changeIndex.row[rowKey]
-        } else if (cellKey in changeIndex.cell) {
-          change = changeIndex.cell[cellKey]
-        }
-        if (change) {
-          cellProps.style.color = 'black'
-          cellProps.style.border = '1px solid ' + colorPalette.OKFNBlue.main
-          cellProps.style.backgroundColor = colorPalette.OKFNGray100.main
-          return value
-        }
-
-        // Errors
-        let error: types.IError | undefined
-        if (rowKey in errorIndex.row) {
-          error = errorIndex.row[rowKey][0]
-        } else if (cellKey in errorIndex.cell) {
-          error = errorIndex.cell[cellKey][0]
-        }
-        if (error) {
-          value = error.cell || value
-          cellProps.style.color = 'white'
-          cellProps.style.cursor = 'pointer'
-          cellProps.style.background = colorPalette.OKFNRed400.main
-          value = (
-            <LightTooltip title={error.message}>
-              <div>{value}</div>
-            </LightTooltip>
-          )
-        }
-
-        return value
-      },
+      headerProps: labelErrors
+        ? { style: { color: 'white', background: colorPalette.OKFNRed400.main } }
+        : field.name === selection?.columnName
+        ? { style: { color: '#ed6c02' } }
+        : undefined,
+      render: renderRow,
     })
   }
 

--- a/client/types/error.ts
+++ b/client/types/error.ts
@@ -8,6 +8,7 @@ export interface IError {
   fieldNumber?: number
   fieldName?: string
   labels?: string[]
+  label?: string
   cells?: string[]
   cell?: any
 }


### PR DESCRIPTION
- fixes #563 

---

@romicolman 
I don't think we can easily change the situation described in #563 as any save of the file does a few automatic normalizations:
- fill empty labels
- remove extra cells
- etc

This behaviour is implemented in `frictionless-py` and changing it might be quite complicated especially taking into account that these normalizations are done towards fixing tabular errors.

This PR just fixes the missing empty row tooltip.