### PR TITLE
Fix Table Schema constraints handling

### DIFF
--- a/client/components/Editors/Schema/Sections/Fields.tsx
+++ b/client/components/Editors/Schema/Sections/Fields.tsx
@@ -421,7 +421,10 @@ function Required() {
       label="Required"
       onFocus={() => updateHelp('schema/fields/required')}
       value={constraints?.required || false}
-      onChange={(required) => updateField({ constraints: { ...constraints, required } })}
+      onChange={(value) => {
+        const required = value || undefined
+        updateField({ constraints: { ...constraints, required } })
+      }}
     />
   )
 }

--- a/client/components/Editors/Schema/Sections/Fields.tsx
+++ b/client/components/Editors/Schema/Sections/Fields.tsx
@@ -416,6 +416,7 @@ function Required() {
   const updateField = useStore((state) => state.updateField)
   const constraints = useStore(select(selectors.field, (field) => field.constraints))
   const updateHelp = useStore((state) => state.updateHelp)
+
   return (
     <YesNoField
       label="Required"
@@ -661,15 +662,17 @@ function MinLength() {
   const updateField = useStore((state) => state.updateField)
   const constraints = useStore(select(selectors.field, (field) => field.constraints))
   const updateHelp = useStore((state) => state.updateHelp)
+
   return (
     <InputField
-      type="number"
+      type="integer"
       label="Min Length"
       value={constraints?.minLength || ''}
       onFocus={() => updateHelp('schema/fields/minLength')}
-      onChange={(value) =>
-        updateField({ constraints: { ...constraints, minLength: parseInt(value) } })
-      }
+      onChange={(value) => {
+        const minLength = value ? parseInt(value) : undefined
+        updateField({ constraints: { ...constraints, minLength } })
+      }}
     />
   )
 }
@@ -678,15 +681,17 @@ function MaxLength() {
   const updateField = useStore((state) => state.updateField)
   const constraints = useStore(select(selectors.field, (field) => field.constraints))
   const updateHelp = useStore((state) => state.updateHelp)
+
   return (
     <InputField
-      type="number"
+      type="integer"
       label="Max Length"
       value={constraints?.maxLength || ''}
       onFocus={() => updateHelp('schema/fields/maxLength')}
-      onChange={(value) =>
-        updateField({ constraints: { ...constraints, maxLength: parseInt(value) } })
-      }
+      onChange={(value) => {
+        const maxLength = value ? parseInt(value) : undefined
+        updateField({ constraints: { ...constraints, maxLength } })
+      }}
     />
   )
 }
@@ -695,13 +700,17 @@ function Pattern() {
   const updateField = useStore((state) => state.updateField)
   const constraints = useStore(select(selectors.field, (field) => field.constraints))
   const updateHelp = useStore((state) => state.updateHelp)
+
   return (
     <InputField
       type="string"
       label="Pattern"
       value={constraints?.pattern || ''}
       onFocus={() => updateHelp('schema/fields/pattern')}
-      onChange={(pattern) => updateField({ constraints: { ...constraints, pattern } })}
+      onChange={(value) => {
+        const pattern = value || undefined
+        updateField({ constraints: { ...constraints, pattern } })
+      }}
     />
   )
 }

--- a/client/components/Editors/Schema/Sections/Fields.tsx
+++ b/client/components/Editors/Schema/Sections/Fields.tsx
@@ -595,12 +595,14 @@ function MinimumNumber() {
   const constraints = useStore(select(selectors.field, (field) => field.constraints))
   const updateHelp = useStore((state) => state.updateHelp)
   const [isValid, setIsValid] = React.useState(isValidMinimumNumber())
+
   function isValidMinimumNumber() {
     if (!constraints) return true
     return constraints.minimum
       ? validator.isNumeric(constraints.minimum.toString())
       : true
   }
+
   return (
     <InputField
       error={!isValid}
@@ -611,9 +613,10 @@ function MinimumNumber() {
       onBlur={() => {
         setIsValid(isValidMinimumNumber())
       }}
-      onChange={(value) =>
-        updateField({ constraints: { ...constraints, minimum: parseInt(value) } })
-      }
+      onChange={(value) => {
+        const minimum = value || undefined
+        updateField({ constraints: { ...constraints, minimum } })
+      }}
       helperText={!isValid ? 'Minimum value is not valid.' : ''}
     />
   )
@@ -624,12 +627,14 @@ function MaximumNumber() {
   const constraints = useStore(select(selectors.field, (field) => field.constraints))
   const updateHelp = useStore((state) => state.updateHelp)
   const [isValid, setIsValid] = React.useState(isValidMaximumNumber())
+
   function isValidMaximumNumber() {
     if (!constraints) return true
     return constraints.maximum
       ? validator.isNumeric(constraints.maximum.toString())
       : true
   }
+
   return (
     <InputField
       error={!isValid}
@@ -640,9 +645,10 @@ function MaximumNumber() {
       onBlur={() => {
         setIsValid(isValidMaximumNumber())
       }}
-      onChange={(value) =>
-        updateField({ constraints: { ...constraints, maximum: parseInt(value) } })
-      }
+      onChange={(value) => {
+        const maximum = value || undefined
+        updateField({ constraints: { ...constraints, maximum } })
+      }}
       helperText={!isValid ? 'Maximum value is not valid.' : ''}
     />
   )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,14 @@ requires-python = ">=3.11"
 dependencies = [
     # Core
     "fastapi==0.103.1",
-    "frictionless==5.16.0",
+    "frictionless==5.18.0",
     "gitignore-parser==0.1.6",
     "openai==0.28.0",
     "pydantic==2.3.0",
     "python-multipart==0.0.6",
     "sqlalchemy==2.0.20",
     "tinydb==4.8.0",
-    "typer==0.9.0",
+    "typer==0.12.0",
     "typing_extensions==4.8.0",
     "uvicorn==0.23.2",
     # Gsheets

--- a/server/helpers/resource.py
+++ b/server/helpers/resource.py
@@ -22,6 +22,7 @@ def index_resource(project: Project, resource: Resource, table_name: str):
             database=db.engine,
             table_name=table_name,
             with_metadata=True,
+            ignore_constraints=True,
         )
         report = indexer.index()
 


### PR DESCRIPTION
- new flag implemented in `fricitonless-py` - https://github.com/frictionlessdata/frictionless-py/pull/1691
- fixes #552 
- fixes #554
- fixes #555

---

Tested constraints:

- [x] string/required
- [x] string/minLength
- [x] string/maxLength
- [x] string/enum
- [x] string/pattern
- [x] integer/required
- [x] integer/minimum
- [x] integer/maximum
- [x] integer/enum
- [x] number/required
- [x] number/minimum
- [x] number/maximum
- [x] number/enum
- [x] boolean/required
- [x] boolean/enum

