### PR TITLE
Make build in CI for Mac 13, not for latest

### DIFF
--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -78,7 +78,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-14, windows-latest]
+        os: [ubuntu-20.04, macos-13, windows-latest]
     runs-on: ${{ matrix.os }}
     needs: [test, test-e2e]
     steps:
@@ -118,7 +118,7 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-14, windows-latest]
+        os: [ubuntu-20.04, macos-13, windows-latest]
     runs-on: ${{ matrix.os }}
     needs: [test, test-e2e]
     steps:

--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -75,6 +75,12 @@ jobs:
   # Build
   # For GNU/Linux we need to build our application in the oldest version we want to support.
   # https://pyinstaller.org/en/stable/usage.html?highlight=glibc#making-gnu-linux-apps-forward-compatible
+  # 
+  # The reason we chose macos-13 as the minimum version:
+  # https://forums.developer.apple.com/forums/thread/739988
+  # "macOS 14 introduced a new container data protection feature. To learn more about that, 
+  # see the link in Trusted Execution Resources.The solution here is to sign your code with a stable signing identity. 
+  # For day-to-day development, that should be your Apple Development signing identity."
   build:
     strategy:
       matrix:

--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -78,7 +78,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     needs: [test, test-e2e]
     steps:
@@ -118,7 +118,7 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     needs: [test, test-e2e]
     steps:


### PR DESCRIPTION
It has been reported that the built version is not running in older versions of Mac. I have created this PR to target version 13 in mac for the generated build in CI to see if this solves the issue.

---------------------------

@roll we have created this PR to address the issue that the app is not installing in mac versions 14+, I have made a build for mac-13 that has been tested in `mac-13` and `mac-14` and installs the app successfully. (Tested by @Faithkenny and @romicolman manually).

The possible explanation can be found on this thread:

```
https://forums.developer.apple.com/forums/thread/739988
Right. macOS 14 introduced a new container data protection feature. To learn more about that, see the link in Trusted Execution Resources.The solution here is to sign your code with a stable signing identity. For day-to-day development, that should be your Apple Development signing identity. Do this locally and on your CI system. 
```

I would suggest that we target macos-13 for now as our build version until we solve the certificate issue. And anyway targetting the latest version is not the best idea, we need to target older versions as well.  