### PR TITLE
Rename column functionality

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -31,6 +31,10 @@ export class Client {
     return await this.request<{ columns: types.IColumn[] }>('/column/list')
   }
 
+  async columnRename(props: { path: string; oldName: string; newName: string }) {
+    return await this.request<Record<string, never>>('/column/rename', props)
+  }
+
   // Config
 
   async configRead(props: Record<string, never> = {}) {

--- a/client/components/Controllers/Table/Editor.tsx
+++ b/client/components/Controllers/Table/Editor.tsx
@@ -50,6 +50,7 @@ export default function Editor() {
           onEditStop={store.stopTableEditing}
           defaultCellSelection={cellSelection}
           onCellSelectionChange={setCellSelection}
+          onColumnRename={store.renameColumn}
           handle={(ref) => store.setRefs({ grid: ref })}
         />
       </Box>

--- a/client/components/Editors/Base/List.tsx
+++ b/client/components/Editors/Base/List.tsx
@@ -9,15 +9,17 @@ import HeadingBox from './Heading/Box'
 export interface EditorListProps {
   kind: string
   query?: string
-  onAddClick: () => void
+  onAddClick?: () => void
   // We accept search as a prop otherwise it loses focus
   SearchInput?: React.ReactNode
 }
 
 export default function EditorList(props: React.PropsWithChildren<EditorListProps>) {
   const AddButton = () => {
+    if (!props.onAddClick) return null
+
     return (
-      <Button title={`Add ${startCase(props.kind)}`} onClick={() => props.onAddClick()}>
+      <Button title={`Add ${startCase(props.kind)}`} onClick={() => props.onAddClick?.()}>
         Add {startCase(props.kind)}
       </Button>
     )

--- a/client/components/Editors/Base/ListItem.tsx
+++ b/client/components/Editors/Base/ListItem.tsx
@@ -16,27 +16,37 @@ interface EditorListItemProps {
 
 export default function EditorListItem(props: EditorListItemProps) {
   const theme = useTheme()
+
+  const RemoveButton = () => {
+    if (!props.onRemoveClick) return null
+
+    return (
+      <Button
+        size="small"
+        color="warning"
+        component="span"
+        title={`Remove ${capitalize(props.kind)}`}
+        sx={{ marginLeft: 2, textDecoration: 'underline' }}
+        onClick={(ev) => {
+          ev.stopPropagation()
+          props.onRemoveClick?.()
+        }}
+      >
+        Remove
+      </Button>
+    )
+  }
+
   const EndIcon = () => {
     const label = (props.type || 'item').toUpperCase()
     return (
       <Box>
         <Typography component="span">{label}</Typography>
-        <Button
-          size="small"
-          color="warning"
-          component="span"
-          title={`Remove ${capitalize(props.kind)}`}
-          sx={{ marginLeft: 2, textDecoration: 'underline' }}
-          onClick={(ev) => {
-            ev.stopPropagation()
-            props.onRemoveClick && props.onRemoveClick()
-          }}
-        >
-          Remove
-        </Button>
+        <RemoveButton />
       </Box>
     )
   }
+
   return (
     <Button
       size="large"

--- a/client/components/Editors/Schema/Sections/Fields.tsx
+++ b/client/components/Editors/Schema/Sections/Fields.tsx
@@ -28,7 +28,6 @@ function FieldList() {
   const query = useStore((state) => state.fieldState.query)
   const fieldItems = useStore(selectors.fieldItems)
   const updateFieldState = useStore((state) => state.updateFieldState)
-  const removeField = useStore((state) => state.removeField)
 
   return (
     <EditorList
@@ -48,7 +47,6 @@ function FieldList() {
           name={field.title || field.name}
           type={field.type}
           onClick={() => updateFieldState({ index })}
-          onRemoveClick={() => removeField(index)}
         />
       ))}
     </EditorList>

--- a/client/components/Editors/Schema/Sections/Fields.tsx
+++ b/client/components/Editors/Schema/Sections/Fields.tsx
@@ -116,6 +116,7 @@ function Name() {
 
   return (
     <InputField
+      disabled
       label="Name"
       value={value}
       error={!value}

--- a/client/components/Editors/Schema/Sections/Fields.tsx
+++ b/client/components/Editors/Schema/Sections/Fields.tsx
@@ -28,13 +28,12 @@ function FieldList() {
   const query = useStore((state) => state.fieldState.query)
   const fieldItems = useStore(selectors.fieldItems)
   const updateFieldState = useStore((state) => state.updateFieldState)
-  const addField = useStore((state) => state.addField)
   const removeField = useStore((state) => state.removeField)
+
   return (
     <EditorList
       kind="field"
       query={query}
-      onAddClick={() => addField()}
       SearchInput={
         <EditorSearch
           value={query || ''}

--- a/client/components/Editors/Schema/Sections/Fields.tsx
+++ b/client/components/Editors/Schema/Sections/Fields.tsx
@@ -44,7 +44,7 @@ function FieldList() {
         <EditorListItem
           key={index}
           kind="field"
-          name={field.title || field.name}
+          name={field.name}
           type={field.type}
           onClick={() => updateFieldState({ index })}
         />

--- a/client/components/Editors/Table/columns.tsx
+++ b/client/components/Editors/Table/columns.tsx
@@ -46,7 +46,7 @@ export function createColumns(
 
     const renderHeader: IColumn['header'] = () => {
       const firstError = labelErrors?.[0]
-      const label = firstError ? firstError.label : field.title ?? field.name
+      const label = firstError ? firstError.label : field.name
 
       if (firstError) {
         return (

--- a/client/components/Editors/Table/index.tsx
+++ b/client/components/Editors/Table/index.tsx
@@ -60,8 +60,8 @@ export default function TableEditor(props: TableEditorProps) {
       menuProps.items.push({
         itemId: 'rename',
         label: 'Rename',
+        disabled: history?.changes.length,
         onClick: () => {
-          console.log(context.cellProps)
           setDialog({
             type: 'columnRename',
             name: context.cellProps.name,
@@ -71,7 +71,7 @@ export default function TableEditor(props: TableEditorProps) {
       })
       return undefined
     },
-    []
+    [history?.changes.length]
   )
 
   function resizeTable() {

--- a/client/components/Editors/Table/index.tsx
+++ b/client/components/Editors/Table/index.tsx
@@ -91,6 +91,7 @@ export default function TableEditor(props: TableEditorProps) {
     <>
       <ColumnRenameDialog
         dialog={dialog}
+        schema={schema}
         onClose={() => setDialog(undefined)}
         onColumnRename={onColumnRename}
       />
@@ -128,21 +129,33 @@ type IColumnRenameDialog = {
 function ColumnRenameDialog(props: {
   dialog?: IDialog
   onClose: () => void
-  onColumnRename?: React.ComponentProps<typeof TableEditor>['onColumnRename']
+  schema: types.ISchema
+  onColumnRename: React.ComponentProps<typeof TableEditor>['onColumnRename']
 }) {
   if (props.dialog?.type !== 'columnRename') return null
 
   const [name, setName] = React.useState(props.dialog.name)
 
+  const isUpdated = name !== props.dialog.name
+  const isUnique = !props.schema.fields.map((field) => field.name).includes(name)
+
+  let errorMessage = ''
+  if (!name) {
+    errorMessage = 'Name must not be blank'
+  } else if (isUpdated && !isUnique) {
+    errorMessage = 'Name must be unique'
+  }
+
   return (
     <InputDialog
       open={true}
       value={name}
-      description="Edit the column name"
+      description="Enter a new column name:"
       onChange={setName}
-      title="Rename Column"
+      title={`Rename Column "${props.dialog.name}"`}
       onCancel={props.onClose}
-      disabled={!name || name === props.dialog.name}
+      disabled={!isUpdated || !!errorMessage}
+      errorMessage={errorMessage}
       onConfirm={() => {
         props.onColumnRename?.({
           index: props.dialog!.index,

--- a/client/components/Parts/Dialogs/Input.tsx
+++ b/client/components/Parts/Dialogs/Input.tsx
@@ -26,7 +26,7 @@ export default function InputDialog(props: InputDialogProps) {
     >
       <TextField
         error={!!errorMessage}
-        helperText={errorMessage}
+        helperText={errorMessage || ' '}
         autoFocus
         fullWidth
         size="small"
@@ -42,7 +42,6 @@ export default function InputDialog(props: InputDialogProps) {
             <InputAdornment position="start">{prefix}</InputAdornment>
           ) : undefined,
         }}
-        sx={{ marginBottom: 1 }}
       />
       {props.children}
     </ConfirmDialog>

--- a/client/components/Parts/Dialogs/Input.tsx
+++ b/client/components/Parts/Dialogs/Input.tsx
@@ -15,11 +15,15 @@ export interface InputDialogProps extends Omit<ConfirmDialogProps, 'onConfirm'> 
 
 export default function InputDialog(props: InputDialogProps) {
   const { prefix, placholder, spellcheck, onConfirm, errorMessage, ...rest } = props
-  const [value, setValue] = React.useState('')
+  const [value, setValue] = React.useState(props.value || '')
 
   const handleConfirm = () => onConfirm && onConfirm(value)
   return (
-    <ConfirmDialog {...rest} onConfirm={handleConfirm} disabled={!value}>
+    <ConfirmDialog
+      {...rest}
+      onConfirm={handleConfirm}
+      disabled={props.disabled || !value}
+    >
       <TextField
         error={!!errorMessage}
         helperText={errorMessage}

--- a/client/store/actions/table.ts
+++ b/client/store/actions/table.ts
@@ -1,4 +1,5 @@
 import { client } from '@client/client'
+import invariant from 'tiny-invariant'
 import { mapValues, isNull } from 'lodash'
 import { onFileCreated, onFileUpdated } from './file'
 import { cloneDeep } from 'lodash'
@@ -273,6 +274,28 @@ export async function deleteMultipleCells(cells: types.ICellSelection) {
   })
 
   helpers.applyTableHistory({ changes: [change] }, grid.data)
+}
+
+export async function renameColumn(props: {
+  index: number
+  oldName: string
+  newName: string
+}) {
+  const { grid } = getRefs()
+  const { path } = store.getState()
+  invariant(grid)
+  invariant(path)
+
+  const result = await client.columnRename({ ...props, path })
+
+  if (result instanceof client.Error) {
+    return store.setState('rename-column-error', (state) => {
+      state.error = result
+    })
+  }
+
+  await onFileUpdated([path])
+  grid.reload()
 }
 
 // Loaders

--- a/server/endpoints/column/__init__.py
+++ b/server/endpoints/column/__init__.py
@@ -1,2 +1,2 @@
 # Register modules
-from . import list
+from . import list, rename

--- a/server/endpoints/column/rename.py
+++ b/server/endpoints/column/rename.py
@@ -13,6 +13,7 @@ from ...router import router
 
 class Props(BaseModel, extra="forbid"):
     path: str
+    index: int
     oldName: str
     newName: str
 
@@ -49,7 +50,12 @@ def action(project: Project, props: Props) -> Result:
         resource = TableResource(path=db.database_url, control=control)
         resource.write_table(path=str(target))
 
-    # Reset record
+    # Patch/reset record
+    resource = TableResource.from_descriptor(record.resource)
+    for index, field in enumerate(resource.schema.fields):
+        if index == props.index:
+            field.name = props.newName
+    helpers.patch_record(project, path=props.path, resource=resource.to_dict())
     helpers.reset_record(project, path=props.path)
 
     return Result()

--- a/server/endpoints/column/rename.py
+++ b/server/endpoints/column/rename.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from fastapi import Request
+from frictionless.formats.sql import SqlControl
+from frictionless.resources import TableResource
+from pydantic import BaseModel
+
+from ... import helpers
+from ...project import Project
+from ...router import router
+
+
+class Props(BaseModel, extra="forbid"):
+    path: str
+    oldName: str
+    newName: str
+
+
+class Result(BaseModel, extra="forbid"):
+    pass
+
+
+@router.post("/column/rename")
+def endpoint(request: Request, props: Props) -> Result:
+    return action(request.app.get_project(), props)
+
+
+def action(project: Project, props: Props) -> Result:
+    fs = project.filesystem
+    db = project.database
+
+    record = helpers.read_record_or_raise(project, path=props.path)
+
+    # Rename column
+    with db.engine.begin() as conn:
+        # Escape column names
+        oldName = escape_column_name(props.oldName)
+        newName = escape_column_name(props.newName)
+
+        # Alter table
+        query = f'ALTER TABLE "{record.name}" RENAME COLUMN "{oldName}" TO "{newName}"'
+        conn.execute(sa.text(query))
+        db.metadata.reflect(conn)
+
+        # Export table
+        target = fs.get_fullpath(props.path)
+        control = SqlControl(table=record.name, with_metadata=True)
+        resource = TableResource(path=db.database_url, control=control)
+        resource.write_table(path=str(target))
+
+    # Reset record
+    helpers.reset_record(project, path=props.path)
+
+    return Result()
+
+
+# https://stackoverflow.com/questions/41383538/how-to-escape-double-quote-in-string-in-sqlite-query
+def escape_column_name(name: str):
+    return name.replace('"', '""')


### PR DESCRIPTION
- fixes #571 
- fixes #574

---

After deep investigation the conclusion was that it's basically impossible to keep all the editing functionality at the same time without falling into a rabbit hole and unmaintainable code. There are data changes, metadata changes, undo, redo + this feature requires special kind of changes -- DDL command on the database that affects both data and metadata.

I think the only robust solution is what is implemented in this PR:
- disabled field name editing in metadata
- disabled adding new fields in metadata (needs a new feature on the data grid -- create issue)
- disabled removing new fields in metadata (needs a new feature on the data grid -- create issue)
- column renaming is implemented a separate action available in the data grid
- currently, the column context menu is used because clicking on the column name does ordering

![ode](https://github.com/user-attachments/assets/fc6926cf-d1f1-47fb-bc69-687ef7b57340)

