### PR TITLE
Improve remote file uploading error indication

### DIFF
--- a/client/components/Application/Dialogs/UploadFile/UploadFile.tsx
+++ b/client/components/Application/Dialogs/UploadFile/UploadFile.tsx
@@ -2,9 +2,9 @@ import uploadFilesDialogImg from '@client/assets/dialog_upload_files.png'
 import iconUploadFolderImg from '@client/assets/folder-open-big-plus.png'
 import iconLinkTextField from '@client/assets/icon_link_textfield.svg'
 import iconUploadFileImg from '@client/assets/icon_upload_file.png'
-import SimpleTabs from '@client/components/Parts/Tabs/SimpleTabs'
 import SimpleButton from '@client/components/Parts/Buttons/SimpleButton'
 import Columns from '@client/components/Parts/Grids/Columns'
+import SimpleTabs from '@client/components/Parts/Tabs/SimpleTabs'
 import { LinearProgress } from '@client/components/Progress'
 import * as appStore from '@client/store'
 import CloseIcon from '@mui/icons-material/Close'
@@ -108,7 +108,7 @@ function LocalFileForm(props: { isFolder?: boolean }) {
           webkitdirectory={props.isFolder ? '' : undefined}
           onChange={(ev) => {
             if (ev.target.files) {
-              store.ingestFiles({ source: ev.target.files }, t)
+              store.ingestFiles({ source: ev.target.files })
             }
           }}
         />
@@ -153,7 +153,7 @@ function RemoteFileForm() {
         hoverBgColor="OKFNBlue"
         color="OKFNBlack"
         disabled={!url}
-        onClick={() => store.ingestFiles({ source: url }, t)}
+        onClick={() => store.ingestFiles({ source: url })}
       />
     </Box>
   )

--- a/client/components/Application/Dialogs/UploadFile/store.tsx
+++ b/client/components/Application/Dialogs/UploadFile/store.tsx
@@ -24,14 +24,14 @@ export function closeDialog() {
   }
 }
 
-export async function ingestFiles(props: { source: FileList | string }, t: any) {
+export async function ingestFiles(props: { source: FileList | string }) {
   const files =
     props.source instanceof FileList
       ? await uploadLocalFiles({ source: props.source })
-      : await uploadRemoteFile({ source: props.source }, t)
+      : await uploadRemoteFile({ source: props.source })
 
   if (files) {
-    await validateAndSelectFiles({ files }, t)
+    await validateAndSelectFiles({ files })
   }
 }
 
@@ -57,7 +57,7 @@ async function uploadLocalFiles(props: { source: FileList }) {
   return files
 }
 
-async function uploadRemoteFile(props: { source: string }, t: any) {
+async function uploadRemoteFile(props: { source: string }) {
   state.progress = { type: 'loading', title: t('loading'), blocking: true }
 
   if (!props.source) {
@@ -85,7 +85,7 @@ async function uploadRemoteFile(props: { source: string }, t: any) {
   return [result]
 }
 
-async function validateAndSelectFiles(props: { files: IFile[] }, t: any) {
+async function validateAndSelectFiles(props: { files: IFile[] }) {
   state.progress = { type: 'validating', title: t('checking-errors'), blocking: true }
 
   const totalSize = props.files.reduce((acc, file) => acc + file.size, 0)

--- a/client/components/Application/Dialogs/UploadFile/store.tsx
+++ b/client/components/Application/Dialogs/UploadFile/store.tsx
@@ -74,9 +74,10 @@ async function uploadRemoteFile(props: { source: string }) {
   const result = await client.fileFetch({ folder, url: props.source, deduplicate: true })
 
   if (result instanceof client.Error) {
+    console.log(result)
     const message = props.source.includes('docs.google.com/spreadsheets')
       ? t('error-google-sheets-address-invalid')
-      : t('error-url-not-table')
+      : t(result.detail as any)
     state.progress = { type: 'error', message }
     return
   }

--- a/server/endpoints/file/create.py
+++ b/server/endpoints/file/create.py
@@ -25,6 +25,11 @@ class Result(BaseModel, extra="forbid"):
     size: int
 
 
+# TODO: this operation needs to be atomic (has to include file creation and table validation)
+# it will allow proper clean-ups in case of errors and better error messages
+# (see "/file/fetch" as an example)
+
+
 @router.post("/file/create")
 async def endpoint(
     request: Request,

--- a/server/endpoints/file/fetch.py
+++ b/server/endpoints/file/fetch.py
@@ -31,6 +31,10 @@ def server_file_read(request: Request, props: Props) -> Result:
     return action(request.app.get_project(), props)
 
 
+# TODO: implement proper cleanup in case of failed uploading
+# currently, it only cleanups if the file is not a table
+
+
 def action(project: Project, props: Props) -> Result:
     from ... import endpoints
 
@@ -65,11 +69,11 @@ def action(project: Project, props: Props) -> Result:
     ).record
 
     # Ensure tabular
-    # Currently, we support only fetching tabular files because otherwise
-    # it's not possible to differentiate between HTML documents (wrong links) and data files
     if record.type != "table":
         endpoints.file.delete.action(project, endpoints.file.delete.Props(path=path))
-        raise Exception("The file is not tabular")
+        # TODO: currently, we just use a tranlation key here
+        # later it might need to be migrated to proper error codes
+        raise Exception("error-url-not-table")
 
     return Result(path=path, size=len(bytes))
 


### PR DESCRIPTION
- fixes #678
- removes unused `t` argument
- adds some architectural TODOs

---

@romicolman 
This file seems to be not-properly encoded so `frictionless-py` can' read it. The only thing we can do at the moment is to improve an error message which is covered by this PR. Also, for now, it's not translated as the whole class of `frictionless-py` error messages need to be translated (it's just one case).
