### PR TITLE
Update open-ai version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 frictionless==5.18.0
 openpyxl==3.1.5
 PySide6==6.8.0.2
-openai==1.55.3
+openai==1.61.1


### PR DESCRIPTION
While trying to test 712-migrate-to-pyside6, running `make start` produced this error;

```python3
python -m ode.main
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/ibiam/opendataeditor/ode/main.py", line 22, in <module>
    from ode.ai_widget import ChatGPTDialog
  File "/home/ibiam/opendataeditor/ode/ai_widget.py", line 6, in <module>
    from openai import OpenAI
ImportError: cannot import name 'OpenAI' from 'openai'
(/home/ibiam/opendataeditor/.python/opendataeditor/lib/python3.11/site-packages/openai/__init__.py)
make: *** [Makefile:18: start] Error 1
```

upgrading the open-ai version fixes it and the editor runs as expected.

- fixes #<issue-number>

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
