### PR TITLE
Delete Metadata as well as file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tmp/
 node_modules/
 .astro
 package-lock.json
+/.venv

--- a/ode/main.py
+++ b/ode/main.py
@@ -198,7 +198,8 @@ class Sidebar(QWidget):
         """Delete a file/folder from the file navigator (and the OS)."""
         index = self.file_navigator.currentIndex()
         if index.isValid():
-            file_path = self.file_model.filePath(index)
+            file_path = Path(self.file_model.filePath(index))
+            metadata_path = Paths.get_path_to_metadata_file(file_path)
 
             confirm = QMessageBox.question(
                 self, self.tr("Delete"), self.tr("Are you sure you want to delete this?"),
@@ -206,10 +207,12 @@ class Sidebar(QWidget):
             )
             if confirm == QMessageBox.Yes:
                 try:
-                    if os.path.isfile(file_path):
-                        os.remove(file_path)
-                    elif os.path.isdir(file_path):
-                        os.rmdir(file_path)
+                    if file_path.is_file():
+                        file_path.unlink()
+                        metadata_path.unlink()
+                    elif file_path.is_dir():
+                        file_path.rmdir()
+                        metadata_path.rmdir()
                 except OSError as e:
                     QMessageBox.warning(self, self.tr("Error"), self.tr("Failed to delete: {e}").format(e))
 

--- a/ode/panels/metadata.py
+++ b/ode/panels/metadata.py
@@ -343,27 +343,7 @@ class FrictionlessResourceMetadataWidget(QWidget):
         elif form == "Fields":
             self.forms_layout.setCurrentIndex(4)
 
-    def _get_path_to_metadata_file(self, filepath):
-        """Returns the path to the metadata file of the given file.
 
-        Metadata is a JSON object that stores Fricionless Metadata and any other
-        metadata required by ODE. All metadata files are going to be stored in a
-        `.metadata` folder mimicing the file name and the structure of the project
-        folder.
-
-        Example 1:
-          - File: Paths.PROJECT_FOLDER / 'myfile.csv'
-          - Metadata: Paths.PROJECT_FOLDER / '.metadata/myfile.json'
-
-        Example 2 (subfolder):
-          - File: Paths.PROJECT_FOLDER / 'subfolder/invalid-file.csv'
-          - Metadata: Paths.PROJECT_FOLDER / '.metadata/subfolder/invalid-file.json'
-        """
-        filepath = Path(filepath)
-        relative_path = filepath.parent.relative_to(Paths.PROJECT_PATH)
-        metadata_path = Paths.METADATA_PATH / relative_path
-        metadata_filepath = metadata_path / (filepath.stem + '.json')
-        return metadata_filepath
 
     def get_or_create_metadata(self, filepath):
         """Get or create a metadata object for the Resource.
@@ -377,7 +357,7 @@ class FrictionlessResourceMetadataWidget(QWidget):
           "custom_ode_metadata": "custom_ode_metadata_value"
         }
         """
-        metadata_filepath = self._get_path_to_metadata_file(filepath)
+        metadata_filepath = Paths.get_path_to_metadata_file(filepath)
         metadata = dict()
 
         if not metadata_filepath.exists():
@@ -453,7 +433,7 @@ class FrictionlessResourceMetadataWidget(QWidget):
             elif isinstance(form, LicensesForm):
                 self.resource.licenses = form.get_selected_licenses()
 
-        metadata_filepath = self._get_path_to_metadata_file(self.resource.path)
+        metadata_filepath = Paths.get_path_to_metadata_file(self.resource.path)
         metadata = self.get_or_create_metadata(self.resource.path)
         metadata["resource"] = self.resource.to_descriptor()
         with open(metadata_filepath, "w") as f:

--- a/ode/paths.py
+++ b/ode/paths.py
@@ -21,3 +21,26 @@ class Paths:
     @classmethod
     def translation(cls, filename):
         return os.path.join(cls.assets, "translations", filename)
+
+    @classmethod
+    def get_path_to_metadata_file(cls, filepath: str|Path) -> Path:
+        """Returns the path to the metadata file of the given file.
+
+        Metadata is a JSON object that stores Fricionless Metadata and any other
+        metadata required by ODE. All metadata files are going to be stored in a
+        `.metadata` folder mimicing the file name and the structure of the project
+        folder.
+
+        Example 1:
+          - File: Paths.PROJECT_FOLDER / 'myfile.csv'
+          - Metadata: Paths.PROJECT_FOLDER / '.metadata/myfile.json'
+
+        Example 2 (subfolder):
+          - File: Paths.PROJECT_FOLDER / 'subfolder/invalid-file.csv'
+          - Metadata: Paths.PROJECT_FOLDER / '.metadata/subfolder/invalid-file.json'
+        """
+        filepath = Path(filepath) if isinstance(filepath, str) else filepath
+        relative_path = filepath.parent.relative_to(cls.PROJECT_PATH)
+        metadata_path = cls.METADATA_PATH / relative_path
+        metadata_filepath = metadata_path / (filepath.stem + '.json')
+        return metadata_filepath


### PR DESCRIPTION
- fixes #738

This deletes the metadata as well and moves the metadata path calculation into the Paths class.
Also ignore .venv for visual studio

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
