### PR TITLE
Add Errors number to the Errors report button in the toolbar

### DIFF
--- a/ode/assets/style.qss
+++ b/ode/assets/style.qss
@@ -6,16 +6,43 @@ QWidget {
 
 * { gridline-color: lightgrey; } /* multi-os support */
 
-QPushButton {
+.QPushButton {
   font-size: 16px;
   font-weight: 600;
   color: #4C5564;
   border: 0;
   padding: 6px 8px;
 }
-QPushButton:hover {
-    background-color: #F0F0F0;
+.QPushButton:hover {
+  background-color: #F0F0F0;
 }
+
+ErrorsReportButton {
+  border: 0;
+}
+
+ErrorsReportButton:hover {
+  background-color: #F0F0F0;
+}
+
+ErrorsReportButton QLabel {
+  font-size: 16px;
+  font-weight: 600;
+  color: #4C5564;
+  background: transparent;
+}
+
+ErrorsReportButton QLabel:disabled {
+  color: grey;
+}
+
+ErrorsReportButton QLabel[error] {
+  background: #FCF2F2;
+  border: 1px solid #FECBCA;
+  color: red;
+  padding: 0px;
+}
+
 QPushButton#button_save, QPushButton#button_publish {
   font-size: 14px;
   font-weight: 500;

--- a/ode/main.py
+++ b/ode/main.py
@@ -228,7 +228,7 @@ class ErrorsReportButton(QPushButton):
 
     QPushButton (Icon+Text) is not enough since we need a three part button: Icon+Text+ErrorCount.
     In order for the ErrorCount Label to be part of the button (background, hover, clickable) we
-    need to extend the basic QPushButton and override some its layout.
+    need to extend the basic QPushButton and override its layout and some methods.
     """
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/ode/main.py
+++ b/ode/main.py
@@ -250,12 +250,16 @@ class ErrorsReportButton(QPushButton):
         # (auto-expanding content-based width)
         self.layout.setSizeConstraint(QHBoxLayout.SetMinimumSize)
 
-    # Existing methods for text/icon/error management remain the same
     def setText(self, text):
         self.text_label.setText(text)
         self.updateGeometry()  # Force layout recalc
 
     def setIcon(self, icon):
+        """Overrides the QPushButton method to set the icon to our icon_label.
+
+        A difference with QPushButton is that we handle the size here instead of calling
+        QPushButton.setIconSize().
+        """
         if icon.isNull():
             self.icon_label.clear()
         else:
@@ -313,7 +317,6 @@ class Toolbar(QWidget):
         self.button_metadata.setIconSize(QSize(20, 20))
         self.button_errors = ErrorsReportButton(self)
         self.button_errors.setIcon(QIcon(Paths.asset("icons/24/rule.svg")))
-        self.button_errors.setIconSize(QSize(20, 20))
         self.button_source = QPushButton()
         self.button_source.setIcon(QIcon(Paths.asset("icons/24/code.svg")))
         self.button_source.setIconSize(QSize(20, 20))

--- a/ode/main.py
+++ b/ode/main.py
@@ -233,26 +233,21 @@ class ErrorsReportButton(QPushButton):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.layout = QHBoxLayout(self)
-        self.layout.setSpacing(2)  # Match QPushButton look & feel
+        self.layout.setSpacing(2)  # Aligns better with QPushButton look & feel
 
-        # Icon (fixed size based on content)
         self.icon_label = QLabel()
         self.icon_label.setFixedSize(20, 20)  # Match icon size
         self.layout.addWidget(self.icon_label)
 
-        # Text label (auto-expanding content-based width)
         self.text_label = QLabel()
-        self.text_label.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
         self.layout.addWidget(self.text_label)
 
-        # Error number label (auto-expanding content-based width)
         self.error_label = QLabel()
-        self.error_label.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
         self.error_label.setProperty("error", True)  # For referencing in our style.qss file
         self.layout.addWidget(self.error_label)
 
-        # Configure button sizing
-        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        # This is some Qt Magic to properly display the button and of all its labels
+        # (auto-expanding content-based width)
         self.layout.setSizeConstraint(QHBoxLayout.SetMinimumSize)
 
     # Existing methods for text/icon/error management remain the same

--- a/ode/main.py
+++ b/ode/main.py
@@ -255,13 +255,6 @@ class ErrorsReportButton(QPushButton):
         self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.layout.setSizeConstraint(QHBoxLayout.SetMinimumSize)
 
-    # Override size hints for proper content-based sizing
-    def sizeHint(self):
-        return self.layout.totalMinimumSize()
-
-    def minimumSizeHint(self):
-        return self.sizeHint()
-
     # Existing methods for text/icon/error management remain the same
     def setText(self, text):
         self.text_label.setText(text)

--- a/ode/main.py
+++ b/ode/main.py
@@ -339,8 +339,8 @@ class Toolbar(QWidget):
         self.button_save.setMinimumSize(QSize(117, 35))
         self.button_save.setIcon(QIcon(Paths.asset("icons/24/check.svg")))
         self.button_save.setIconSize(QSize(20, 20))
-        self.update_qss_button = QPushButton("QSS")
-        layout.addWidget(self.update_qss_button)
+        # self.update_qss_button = QPushButton("QSS")
+        # layout.addWidget(self.update_qss_button)
         layout.addWidget(self.button_ai)
         layout.addWidget(self.button_publish)
         layout.addWidget(self.button_save)
@@ -509,7 +509,7 @@ class MainWindow(QMainWindow):
         self.translator = QTranslator()
         self.retranslateUI()
 
-        self.content.toolbar.update_qss_button.clicked.connect(self.apply_stylesheet)
+        # self.content.toolbar.update_qss_button.clicked.connect(self.apply_stylesheet)
         self.apply_stylesheet()
 
     def _menu_bar(self):


### PR DESCRIPTION
Fixes #721

This PR implements a new ErrorsReportButton class to display an error count label next to the button.

![image](https://github.com/user-attachments/assets/3625b27b-60ba-402b-9a8a-5e3626ec55c1)
