### PR TITLE
723 Display file after upload

### DIFF
--- a/ode/dialogs/upload.py
+++ b/ode/dialogs/upload.py
@@ -54,7 +54,7 @@ class DataUploadDialog(QDialog):
       ok, path = dialog.upload_dialog()
     """
 
-    def __init__(self, parent):
+    def __init__(self, parent, external_first=False):
         super().__init__(parent)
         self.setFixedHeight(500)
         self.setFixedWidth(500)
@@ -116,6 +116,9 @@ class DataUploadDialog(QDialog):
         # Add Tabs to Tab Widget
         self.tab_widget.addTab(from_computer_tab, "")
         self.tab_widget.addTab(external_data_tab, "")
+
+        if external_first:
+            self.tab_widget.setCurrentIndex(1)
 
         self.setLayout(main_layout)
 
@@ -185,10 +188,6 @@ class DataUploadDialog(QDialog):
         """
         result = self.exec()
         return result, self.target_path
-
-    def show_external_first(self):
-        """Shows the Dialog but with the External tab clicked"""
-        self.tab_widget.setCurrentIndex(1)
 
     def _read_url_html_title(self, url):
         """ Return the title of HTML document.

--- a/ode/dialogs/upload.py
+++ b/ode/dialogs/upload.py
@@ -59,7 +59,7 @@ class DataUploadDialog(QDialog):
         self.setFixedHeight(500)
         self.setFixedWidth(500)
 
-        self.destination_path = ""
+        self.target_path = ""
 
         main_layout = QVBoxLayout()
 
@@ -131,8 +131,8 @@ class DataUploadDialog(QDialog):
         if not filename:
             return
 
-        self.destination_path = Paths.get_unique_destination_filepath(filename)
-        shutil.copy(filename, self.destination_path)
+        self.target_path = Paths.get_unique_destination_filepath(filename)
+        shutil.copy(filename, self.target_path)
         self.accept()
 
     def add_folders(self):
@@ -140,8 +140,8 @@ class DataUploadDialog(QDialog):
         source_folder = QFileDialog.getExistingDirectory(self)
         if source_folder:
             folder_name = os.path.basename(source_folder)
-            self.destination_path = os.path.join(Paths.PROJECT_PATH, folder_name)
-            shutil.copytree(source_folder, self.destination_path, dirs_exist_ok=True)
+            self.target_path = os.path.join(Paths.PROJECT_PATH, folder_name)
+            shutil.copytree(source_folder, self.target_path, dirs_exist_ok=True)
         self.accept()
 
     def load_table_from_url(self):
@@ -163,10 +163,10 @@ class DataUploadDialog(QDialog):
         if table.format == "gsheets":
             filename = self._read_url_html_title(url)
 
-        self.destination_path = Paths.get_unique_destination_filepath(filename + ".csv")
+        self.target_path = Paths.get_unique_destination_filepath(filename + ".csv")
 
         try:
-            with open(self.destination_path, mode='w') as file:
+            with open(self.target_path, mode='w') as file:
                 table.write(file.name)
             self.accept()
         except Exception:
@@ -182,7 +182,7 @@ class DataUploadDialog(QDialog):
 
         """
         result = self.exec()
-        return result, self.destination_path
+        return result, self.target_path
 
     def _read_url_html_title(self, url):
         """ Return the title of HTML document.

--- a/ode/dialogs/upload.py
+++ b/ode/dialogs/upload.py
@@ -55,7 +55,7 @@ class DataUploadDialog(QDialog):
         self.setFixedHeight(500)
         self.setFixedWidth(500)
 
-        self.destination_filepath = ""
+        self.destination_path = ""
 
         main_layout = QVBoxLayout()
 
@@ -127,8 +127,8 @@ class DataUploadDialog(QDialog):
         if not filename:
             return
 
-        self.destination_filepath = Paths.get_unique_destination_filepath(filename)
-        shutil.copy(filename, self.destination_filepath)
+        self.destination_path = Paths.get_unique_destination_filepath(filename)
+        shutil.copy(filename, self.destination_path)
         self.accept()
 
     def add_folders(self):
@@ -136,8 +136,8 @@ class DataUploadDialog(QDialog):
         source_folder = QFileDialog.getExistingDirectory(self)
         if source_folder:
             folder_name = os.path.basename(source_folder)
-            target_folder = os.path.join(Paths.PROJECT_PATH, folder_name)
-            shutil.copytree(source_folder, target_folder, dirs_exist_ok=True)
+            self.destination_path = os.path.join(Paths.PROJECT_PATH, folder_name)
+            shutil.copytree(source_folder, self.destination_path, dirs_exist_ok=True)
         self.accept()
 
     def load_table_from_url(self):
@@ -159,10 +159,10 @@ class DataUploadDialog(QDialog):
         if table.format == "gsheets":
             filename = self._read_url_html_title(url)
 
-        self.destination_filepath = Paths.get_unique_destination_filepath(filename + ".csv")
+        self.destination_path = Paths.get_unique_destination_filepath(filename + ".csv")
 
         try:
-            with open(self.destination_filepath, mode='w') as file:
+            with open(self.destination_path, mode='w') as file:
                 table.write(file.name)
             self.accept()
         except Exception:
@@ -182,7 +182,7 @@ class DataUploadDialog(QDialog):
     def get_uploaded_path(self):
         """Shows the dialog and return the path to the uploaded file."""
         result = self.exec()
-        return result, self.destination_filepath
+        return result, self.destination_path
 
     def _reset_forms(self):
         """Reset inputs and selected tab to initial status.

--- a/ode/dialogs/upload.py
+++ b/ode/dialogs/upload.py
@@ -48,6 +48,13 @@ class DataUploadDialog(QDialog):
     files, folders or URLs. For external URLs we rely on frictionless's
     TableResource to read and write tables hosted in the web or Google
     Spreadsheets.
+
+    The interface is inspired in QFileDIalog.getOpenFileName(...) or
+    QInputDialog.getText(..) methods.
+
+    How to use:
+      dialog = DataUploadDialog(self)
+      ok, path = dialog.get_uploaded_path()
     """
 
     def __init__(self, parent):
@@ -169,29 +176,10 @@ class DataUploadDialog(QDialog):
             error = self.tr("Error: The URL is not associated with a table")
             self.error_text.setText(error)
 
-    def reject(self):
-        """Overrides class method to reset the forms when the user close the dialog."""
-        self._reset_forms()
-        super().reject()
-
-    def accept(self):
-        """Override class method to reset forms when successfully uploading a file."""
-        self._reset_forms()
-        super().accept()
-
     def get_uploaded_path(self):
         """Shows the dialog and return the path to the uploaded file."""
         result = self.exec()
         return result, self.destination_path
-
-    def _reset_forms(self):
-        """Reset inputs and selected tab to initial status.
-
-        We should ensure that everytime the user opens the dialog the state is the initial one.
-        """
-        self.url_input.setText("")
-        self.error_text.setText("")
-        self.tab_widget.setCurrentIndex(0)
 
     def _read_url_html_title(self, url):
         """ Return the title of HTML document.

--- a/ode/dialogs/upload.py
+++ b/ode/dialogs/upload.py
@@ -55,6 +55,8 @@ class DataUploadDialog(QDialog):
         self.setFixedHeight(500)
         self.setFixedWidth(500)
 
+        self.destination_filepath = ""
+
         main_layout = QVBoxLayout()
 
         # Centered Image
@@ -125,8 +127,8 @@ class DataUploadDialog(QDialog):
         if not filename:
             return
 
-        destination_filepath = Paths.get_unique_destination_filepath(filename)
-        shutil.copy(filename, destination_filepath)
+        self.destination_filepath = Paths.get_unique_destination_filepath(filename)
+        shutil.copy(filename, self.destination_filepath)
         self.accept()
 
     def add_folders(self):
@@ -157,10 +159,10 @@ class DataUploadDialog(QDialog):
         if table.format == "gsheets":
             filename = self._read_url_html_title(url)
 
-        destination_filepath = Paths.get_unique_destination_filepath(filename + ".csv")
+        self.destination_filepath = Paths.get_unique_destination_filepath(filename + ".csv")
 
         try:
-            with open(destination_filepath, mode='w') as file:
+            with open(self.destination_filepath, mode='w') as file:
                 table.write(file.name)
             self.accept()
         except Exception:
@@ -176,6 +178,11 @@ class DataUploadDialog(QDialog):
         """Override class method to reset forms when successfully uploading a file."""
         self._reset_forms()
         super().accept()
+
+    def get_uploaded_path(self):
+        """Shows the dialog and return the path to the uploaded file."""
+        result = self.exec()
+        return result, self.destination_filepath
 
     def _reset_forms(self):
         """Reset inputs and selected tab to initial status.

--- a/ode/dialogs/upload.py
+++ b/ode/dialogs/upload.py
@@ -51,7 +51,7 @@ class DataUploadDialog(QDialog):
 
     How to use:
       dialog = DataUploadDialog(self)
-      ok, path = dialog.get_uploaded_path()
+      ok, path = dialog.upload_dialog()
     """
 
     def __init__(self, parent):
@@ -173,7 +173,7 @@ class DataUploadDialog(QDialog):
             error = self.tr("Error: The URL is not associated with a table")
             self.error_text.setText(error)
 
-    def get_uploaded_path(self):
+    def upload_dialog(self):
         """Shows the dialog and then returns the result code and the path to the uploaded file.
 
         This method is inspired in QFileDIalog.getOpenFileName(...) and

--- a/ode/dialogs/upload.py
+++ b/ode/dialogs/upload.py
@@ -49,9 +49,6 @@ class DataUploadDialog(QDialog):
     TableResource to read and write tables hosted in the web or Google
     Spreadsheets.
 
-    The interface is inspired in QFileDIalog.getOpenFileName(...) or
-    QInputDialog.getText(..) methods.
-
     How to use:
       dialog = DataUploadDialog(self)
       ok, path = dialog.get_uploaded_path()
@@ -177,7 +174,13 @@ class DataUploadDialog(QDialog):
             self.error_text.setText(error)
 
     def get_uploaded_path(self):
-        """Shows the dialog and return the path to the uploaded file."""
+        """Shows the dialog and then returns the result code and the path to the uploaded file.
+
+        This method is inspired in QFileDIalog.getOpenFileName(...) and
+        QInputDialog.getText(..). When called, this method will display the dialog
+        and return the result code + the path where the file/folder has been copied to.
+
+        """
         result = self.exec()
         return result, self.destination_path
 

--- a/ode/main.py
+++ b/ode/main.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from PySide6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QGridLayout, QVBoxLayout, QHBoxLayout,
     QTreeView, QPushButton, QLabel, QStackedLayout,
-    QComboBox, QMenu, QMessageBox, QInputDialog, QProgressDialog, QSizePolicy
+    QComboBox, QMenu, QMessageBox, QInputDialog, QProgressDialog
 )
 
 from PySide6.QtGui import QPixmap, QIcon, QDesktopServices, QAction

--- a/ode/main.py
+++ b/ode/main.py
@@ -602,7 +602,11 @@ class MainWindow(QMainWindow):
         self.retranslateUI()
 
     def on_button_upload_click(self):
-        """Copy data file to the project folder of ode."""
+        """Copy data file to the project folder of ode.
+
+        After successful upload, we call on_tree_click to update all views as if this
+        file have been selected by the user.
+        """
         dialog = DataUploadDialog(self)
         ok, path = dialog.get_uploaded_path()
         if ok and path:

--- a/ode/main.py
+++ b/ode/main.py
@@ -608,7 +608,7 @@ class MainWindow(QMainWindow):
         file have been selected by the user.
         """
         dialog = DataUploadDialog(self)
-        ok, path = dialog.get_uploaded_path()
+        ok, path = dialog.upload_dialog()
         if ok and path:
             index = self.sidebar.file_model.index(str(path))
             self.on_tree_click(index)

--- a/ode/main.py
+++ b/ode/main.py
@@ -655,10 +655,7 @@ class MainWindow(QMainWindow):
 
         After successful upload the file should be selected, validated, and displayed.
         """
-        dialog = DataUploadDialog(self)
-
-        if external_first:
-            dialog.show_external_first()
+        dialog = DataUploadDialog(self, external_first=external_first)
 
         ok, path = dialog.upload_dialog()
         if ok and path:

--- a/ode/main.py
+++ b/ode/main.py
@@ -70,7 +70,6 @@ class Sidebar(QWidget):
         self.icon_label.setPixmap(pixmap)
         self.icon_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
 
-        self.upload_dialog = DataUploadDialog(self)
         self.button_upload = QPushButton(objectName="button_upload")
 
         self.file_navigator = CustomTreeView()
@@ -124,7 +123,6 @@ class Sidebar(QWidget):
         self.rename_action.setText(self.tr("Rename"))
         self.open_location_action.setText(self.tr("Open File in Location"))
         self.delete_action.setText(self.tr("Delete"))
-        self.upload_dialog.retranslateUI()
 
     def _setup_file_navigator_context_menu(self):
         """Create the context menu for the file navigator."""
@@ -605,7 +603,11 @@ class MainWindow(QMainWindow):
 
     def on_button_upload_click(self):
         """Copy data file to the project folder of ode."""
-        self.sidebar.upload_dialog.show()
+        dialog = DataUploadDialog(self)
+        ok, path = dialog.get_uploaded_path()
+        if ok and path:
+            index = self.sidebar.file_model.index(str(path))
+            self.on_tree_click(index)
 
     def on_save_click(self, checked):
         """Saves changes made in the Table View into the file.
@@ -665,7 +667,7 @@ class MainWindow(QMainWindow):
         a ProgressDialog if it is taking too long. Reading with a worker is
         a requirement to display a proper QProgressDialog.
         """
-        self.selected_file_path = self.sender().model().filePath(index)
+        self.selected_file_path = self.sidebar.file_model.filePath(index)
         info = QFileInfo(self.selected_file_path)
         if info.isFile() and info.suffix() in ['csv', 'xls', 'xlsx']:
             worker = DataWorker(self.selected_file_path)

--- a/ode/main.py
+++ b/ode/main.py
@@ -10,7 +10,10 @@ from PySide6.QtWidgets import (
 )
 
 from PySide6.QtGui import QPixmap, QIcon, QDesktopServices, QAction
-from PySide6.QtCore import Qt, QSize, QFileInfo, QTranslator, QFile, QTextStream, QThreadPool, Slot, Signal, QItemSelectionModel
+from PySide6.QtCore import (
+        Qt, QSize, QFileInfo, QTranslator, QFile, QTextStream, QThreadPool,
+        Slot, Signal, QItemSelectionModel
+    )
 # https://bugreports.qt.io/browse/PYSIDE-1914
 from PySide6.QtWidgets import QFileSystemModel
 

--- a/ode/main.py
+++ b/ode/main.py
@@ -669,9 +669,8 @@ class MainWindow(QMainWindow):
     def read_validate_and_display_file(self, path):
         """Reads a file, validates it and refresh the whole UI.
 
-        This method will be called whenever a file needs to be read, validated and displayed.
-        Usually happens when the user explicitly selects a file in our QTreeView but there could
-        be other workflows in the application that will require this logic like Uploading a File.
+        This method is called when the user selects a file in our QTreeView but there could
+        be other workflows in the application that will require this logic (like Uploading a File).
 
         It will create a Worker to read data in the background and display a ProgressDialog if it
         is taking too long. Reading with a worker is a requirement to display a proper QProgressDialog.


### PR DESCRIPTION
Fixes #723 

### Summary

This PR ended up a little bit more challenging than expected and required a couple of small refactors. Mostly, because I needed to the path of the file uploaded out of the upload dialog to trigger actions like display views and select it in the File Navigator.

1. **DataUploadDialog:** I tried to mimic some Qt behaviour on how it handles Dialogs that returns a value. So instead of having the Dialog as an attribute I create it on the fly and return the value when the dialog is closed. We might be able to move this Dialog as a static class but I didn't want to make more complex than necessary.
2. Since our main logic (read, validate, display) is now shared by two actions (Tree click and Upload) I refactored it into it's own method `read_validate_and_display_file` that can be called from separated actions.
3. I wasn't able to figure out a weird behaviour/side-effect I'm having when retrieving the index of the a file, so I documented it.