### PR TITLE
Populate resource name only if it exists.

### DIFF
--- a/ode/panels/metadata.py
+++ b/ode/panels/metadata.py
@@ -228,6 +228,7 @@ class SchemaForm(QWidget):
         self.description.setText(resource.schema.description)
         # self.missing_values.setText(resource.schema.missing_values)
         self.primary_key.clear()
+        self.primary_key.addItem("")  # Add empty option for non set PrimaryKey.
         for field in resource.schema.fields:
             self.primary_key.addItem(field.name)
 
@@ -483,11 +484,9 @@ class FrictionlessResourceMetadataWidget(QWidget):
                 self.resource.rows = form.rows.value()
             elif isinstance(form, SchemaForm):
                 # SchemaForm
-                if form.name.text():
-                    # Frictionless fails with name='', so we populate only if it has a value.
-                    self.resource.schema.name = form.name.text()
+                self.resource.schema.name = form.name.text() or None
                 self.resource.schema.title = form.title.text()
-                self.resource.schema.primary_key = form.primary_key.currentText()
+                self.resource.schema.primary_key = form.primary_key.currentText() or None
                 # We remove the spaces from the missing values
                 self.resource.schema.missing_values = [m.strip() for m in form.missing_values.text().split(",")]
                 self.resource.schema.description = form.description.text()

--- a/ode/panels/metadata.py
+++ b/ode/panels/metadata.py
@@ -483,7 +483,9 @@ class FrictionlessResourceMetadataWidget(QWidget):
                 self.resource.rows = form.rows.value()
             elif isinstance(form, SchemaForm):
                 # SchemaForm
-                self.resource.schema.name = form.name.text()
+                if form.name.text():
+                    # Frictionless fails with name='', so we populate only if it has a value.
+                    self.resource.schema.name = form.name.text()
                 self.resource.schema.title = form.title.text()
                 self.resource.schema.primary_key = form.primary_key.currentText()
                 # We remove the spaces from the missing values


### PR DESCRIPTION
@rustico this is a small fix to #773.

Changes:
- If we assign `name=''` we will get an error when reading the metadata.
- Add an empty option for Primary Key so it does not always save the first value.

```
Traceback (most recent call last):
  File "/home/pdelboca/Repos/opendataeditor/ode/main.py", line 707, in update_views
    self.content.metadata_widget.populate_all_forms(filepath)
  File "/home/pdelboca/Repos/opendataeditor/ode/panels/metadata.py", line 458, in populate_all_forms
    self.resource = self.get_or_create_metadata(filepath).get("resource")
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/opendataeditor/ode/panels/metadata.py", line 446, in get_or_create_metadata
    resource = TableResource(metadata["resource"])
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/opendataeditor/venv/lib/python3.11/site-packages/frictionless/resource/factory.py", line 63, in __call__
    resource = cls.from_descriptor(  # type: ignore
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/opendataeditor/venv/lib/python3.11/site-packages/frictionless/resource/resource.py", line 437, in from_descriptor
    return super().from_descriptor(descriptor, **options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/opendataeditor/venv/lib/python3.11/site-packages/frictionless/metadata/metadata.py", line 187, in from_descriptor
    raise FrictionlessException(error, reasons=errors)
frictionless.exception.FrictionlessException: [resource-error] The data resource has an error: descriptor is not valid (Schema is not valid: '' does not match '^([-a-z0-9._/])+$' at property 'name')
```

```
Traceback (most recent call last):
  File "/home/pdelboca/Repos/opendataeditor/ode/main.py", line 779, in on_tree_click
    self.read_validate_and_display_file(self.selected_file_path)
  File "/home/pdelboca/Repos/opendataeditor/ode/main.py", line 759, in read_validate_and_display_file
    worker = DataWorker(self.selected_file_path)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/opendataeditor/ode/panels/data.py", line 32, in __init__
    self.resource = self.file.get_or_create_metadata().get("resource")
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/opendataeditor/ode/file.py", line 89, in get_or_create_metadata
    resource = TableResource(metadata["resource"])
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/opendataeditor/venv/lib/python3.11/site-packages/frictionless/resource/factory.py", line 63, in __call__
    resource = cls.from_descriptor(  # type: ignore
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/opendataeditor/venv/lib/python3.11/site-packages/frictionless/resource/resource.py", line 437, in from_descriptor
    return super().from_descriptor(descriptor, **options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/opendataeditor/venv/lib/python3.11/site-packages/frictionless/metadata/metadata.py", line 187, in from_descriptor
    raise FrictionlessException(error, reasons=errors)
frictionless.exception.FrictionlessException: [resource-error] The data resource has an error: descriptor is not valid (Schema is not valid: '' is not of type 'array' at property 'primaryKey')
```
