### PR TITLE
759 Re-validate file when saving

### DIFF
--- a/ode/file.py
+++ b/ode/file.py
@@ -73,7 +73,7 @@ class File:
             self.metadata_path.parent.mkdir(parents=True, exist_ok=True)
             with system.use_context(trusted=True):
                 resource = TableResource(self.path)
-                resource.infer(stats=True)
+                resource.infer()
             with open(self.metadata_path, "w") as f:
                 # Resource is not serializable, converting to dict before writing.
                 metadata["resource"] = resource.to_descriptor()
@@ -87,7 +87,7 @@ class File:
 
         with system.use_context(trusted=True):
             resource = TableResource(metadata["resource"])
-            resource.infer(stats=True)
+            resource.infer()
             metadata["resource"] = resource
 
         return metadata

--- a/ode/main.py
+++ b/ode/main.py
@@ -691,6 +691,7 @@ class MainWindow(QMainWindow):
             return
         self.table_model.write_data(self.selected_file_path)
         self.content.metadata_widget.save_metadata_to_descriptor_file()
+        # TODO: Since the file is already in memory we should only validate/display to avoid unecessary tasks.
         self.read_validate_and_display_file(self.selected_file_path)
 
     @Slot(tuple)

--- a/ode/main.py
+++ b/ode/main.py
@@ -690,8 +690,8 @@ class MainWindow(QMainWindow):
             # TODO: Define behaviour of Save Button
             return
         self.table_model.write_data(self.selected_file_path)
-        self.table_model.layoutChanged.emit()
         self.content.metadata_widget.save_metadata_to_descriptor_file()
+        self.read_validate_and_display_file(self.selected_file_path)
 
     @Slot(tuple)
     def update_views(self, worker_data):

--- a/ode/panels/metadata.py
+++ b/ode/panels/metadata.py
@@ -255,10 +255,20 @@ class IntegrityForm(QWidget):
         self.setLayout(layout)
 
     def populate(self, resource):
-        self.hash.setText(resource.hash)
-        self.fields.setValue(resource.fields)
-        self.bytes_field.setValue(resource.bytes)
-        self.rows.setValue(resource.rows)
+        """Populate form fields.
+
+        This could be populated by setting stats=True when infering metadata.
+        Hash is a little bit tricky because it needs to be updated everytime we
+        edit the file or Frictionless will return a validation error.
+        """
+        if resource.hash:
+            self.hash.setText(resource.hash)
+        if resource.fields:
+            self.fields.setValue(resource.fields)
+        if resource.bytes:
+            self.bytes_field.setValue(resource.bytes)
+        if resource.rows:
+            self.rows.setValue(resource.rows)
 
 
 class ResourceForm(QWidget):
@@ -430,7 +440,7 @@ class FrictionlessResourceMetadataWidget(QWidget):
             file.metadata_path.parent.mkdir(parents=True, exist_ok=True)
             with system.use_context(trusted=True):
                 resource = TableResource(filepath)
-                resource.infer(stats=True)
+                resource.infer()
             with open(file.metadata_path, "w") as f:
                 # Resource is not serializable, converting to dict before writing.
                 metadata["resource"] = resource.to_descriptor()
@@ -444,7 +454,7 @@ class FrictionlessResourceMetadataWidget(QWidget):
 
         with system.use_context(trusted=True):
             resource = TableResource(metadata["resource"])
-            resource.infer(stats=True)
+            resource.infer()
             metadata["resource"] = resource
 
         return metadata

--- a/ode/utils.py
+++ b/ode/utils.py
@@ -44,7 +44,7 @@ def migrate_metadata_store():
                 resource = TableResource(record_data.get("resource"))
                 # Patch the original resource path with the absolute path to the file.
                 resource.path = str(paths.PROJECT_PATH / path)
-                resource.infer(stats=True)
+                resource.infer()
                 record_data["resource"] = resource.to_descriptor()
         except Exception as e:
             # This should happen only if the user did file/metadata editing outside ODE.


### PR DESCRIPTION
Fixes #759 

This PR will implement a re reading, validation and displaying when saving the file.

Given that the file is already in memory, re-reading is not mandatory and we should be able to do only validation/displaying to be more perfomant.

I'm also reverting the `stats=True` (is not available in the stable release) to simplify some write/read logic regarding `hash` validation.

[simplescreenrecorder-2025-03-25_11.22.46.webm](https://github.com/user-attachments/assets/37367380-1234-4bb1-9478-db3bb8e4821a)

 

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
