### PR TITLE
Always use the first row to set field names

### DIFF
--- a/ode/assets/style.qss
+++ b/ode/assets/style.qss
@@ -6,6 +6,10 @@ QWidget {
 
 * { gridline-color: lightgrey; } /* multi-os support */
 
+.QComboBox:disabled, QLineEdit:disabled {
+  background: #f0f0f0;
+}
+
 .QPushButton {
   font-size: 16px;
   font-weight: 600;

--- a/ode/file.py
+++ b/ode/file.py
@@ -140,7 +140,8 @@ class File:
         """
         if self.path.is_file():
             self.path.unlink()
-            self.metadata_path.unlink()
+            if self.metadata_path.exists():
+                self.metadata_path.unlink()
         elif self.path.is_dir():
             shutil.rmtree(self.path)
             if self.metadata_path.exists():

--- a/ode/main.py
+++ b/ode/main.py
@@ -725,7 +725,7 @@ class MainWindow(QMainWindow):
             # TODO: Define behaviour of Save Button
             return
         self.table_model.write_data(self.selected_file_path)
-        self.content.metadata_widget.save_metadata_to_descriptor_file()
+        self.content.metadata_widget.save_metadata_to_descriptor_file(self.table_model)
         # TODO: Since the file is already in memory we should only validate/display to avoid unecessary tasks.
         self.read_validate_and_display_file(self.selected_file_path)
 

--- a/ode/panels/data.py
+++ b/ode/panels/data.py
@@ -119,6 +119,10 @@ class FrictionlessTableModel(QAbstractTableModel):
         except ValueError:
             return 0
 
+    def get_header_data(self):
+        """Returns the first row of the file."""
+        return self._data[0]
+
     def rowCount(self, parent=None):
         """Returning from a pre-calculated private attribute for performance improvements."""
         return self._row_count

--- a/ode/panels/metadata.py
+++ b/ode/panels/metadata.py
@@ -37,6 +37,17 @@ _RESOURCE_METADATA = {
 }
 
 
+class NoWheelComboBox(QComboBox):
+    """QComboBox that disables the mouse wheel event.
+
+    The current UX when scrolling through FieldsForms is not ideal since as soon as
+    the mouse points a QComboBox the form stops scrolling and it starts changing the
+    value of the QComboBox instead.
+    """
+    def wheelEvent(self, event):
+        event.ignore()
+
+
 class LicensesForm(QWidget):
     def __init__(self):
         super().__init__()
@@ -131,7 +142,7 @@ class SingleFieldForm(QWidget):
         layout.addRow("Name: ", self.name)
         # name is read-only since is always updated to the contents of the first row of the file.
         self.name.setDisabled(True)
-        self.types = QComboBox()
+        self.types = NoWheelComboBox()
         self.types.addItems(
             [
                 "any",


### PR DESCRIPTION
Fixes #783 

This PR:
 - Disables FieldForm's name field.
 - When saving the metadata, the names of the fields will always match the first row content.
 - Disables the mouse scrolling of the Field's type QComboBox for a better UX when scrolling long forms.
 - Adds a small validation to check if the metadata file exist before attempting to delete it to.

[simplescreenrecorder-2025-03-27_08.21.03.webm](https://github.com/user-attachments/assets/00c53c49-0fd7-45a5-a889-6482457e24f8)
