### PR TITLE
Fix the Error Report panel showing the missing rows and the correct background for each error type

### DIFF
--- a/ode/panels/data.py
+++ b/ode/panels/data.py
@@ -122,6 +122,10 @@ class FrictionlessTableModel(QAbstractTableModel):
         except ValueError:
             return 0
 
+    def get_header_data(self):
+        """Returns the first row of the file."""
+        return self._data[0]
+
     def rowCount(self, parent=None):
         """Returning from a pre-calculated private attribute for performance improvements."""
         return self._row_count

--- a/ode/panels/data.py
+++ b/ode/panels/data.py
@@ -102,7 +102,10 @@ class FrictionlessTableModel(QAbstractTableModel):
             else:
                 row = error.row_number - 1
                 column = error.field_number - 1
-            result[row] = (column, error.type, error.message)
+            if result[row] is None:
+                result[row] = list()
+
+            result[row].append((column, error.type, error.message))
         return result
 
     def _get_row_count(self):
@@ -153,21 +156,21 @@ class FrictionlessTableModel(QAbstractTableModel):
         if role == Qt.ItemDataRole.BackgroundRole:
             if not self.errors[index.row()]:
                 return
-            error_column, error_type, error_message = self.errors[index.row()]
-            if error_type == "blank-row":
-                # BlankRowError does not have field_number, we paint all the cells.
-                return QColor("red")
-            if error_column == index.column():
-                return QColor("red")
+            for error_column, error_type, error_message in self.errors[index.row()]:
+                if error_type == "blank-row":
+                    # BlankRowError does not have field_number, we paint all the cells.
+                    return QColor("red")
+                if error_column == index.column():
+                    return QColor("red")
         if role == Qt.ItemDataRole.ToolTipRole:
             if not self.errors[index.row()]:
                 return
-            error_column, error_type, error_message = self.errors[index.row()]
-            if error_type == "blank-row":
-                # BlankRowError does not have field_number, we add tooltip to all the cells.
-                return error_message
-            if error_column == index.column():
-                return error_message
+            for error_column, error_type, error_message in self.errors[index.row()]:
+                if error_type == "blank-row":
+                    # BlankRowError does not have field_number, we add tooltip to all the cells.
+                    return error_message
+                if error_column == index.column():
+                    return error_message
 
     def flags(self, index):
         """Enable edition mode"""

--- a/ode/panels/data.py
+++ b/ode/panels/data.py
@@ -209,11 +209,11 @@ class DataViewer(QWidget):
 
         self.label = QLabel()
         self.label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
-        self.data_view = QTableView()
-        self.data_view.hide()
+        self.table_view = QTableView()
+        self.table_view.hide()
 
         layout.addWidget(self.label)
-        layout.addWidget(self.data_view)
+        layout.addWidget(self.table_view)
 
         self.retranslateUI()
 
@@ -223,9 +223,9 @@ class DataViewer(QWidget):
         When a tabular file is selected, the main application will create a
         FrictionlessTableModel and call this function using the model as a parametner.
         """
-        self.data_view.setModel(model)
+        self.table_view.setModel(model)
         self.label.hide()
-        self.data_view.show()
+        self.table_view.show()
 
     def clear(self, model):
         """Reset the view to the default state.
@@ -233,9 +233,9 @@ class DataViewer(QWidget):
         This view depends of the main application self.table_model attribute. This
         method should always receive an empty model
         """
-        self.data_view.setModel(model)
+        self.table_view.setModel(model)
         self.label.show()
-        self.data_view.hide()
+        self.table_view.hide()
 
     def retranslateUI(self):
         """Apply translations to class elements."""

--- a/ode/panels/data.py
+++ b/ode/panels/data.py
@@ -122,10 +122,6 @@ class FrictionlessTableModel(QAbstractTableModel):
         except ValueError:
             return 0
 
-    def get_header_data(self):
-        """Returns the first row of the file."""
-        return self._data[0]
-
     def rowCount(self, parent=None):
         """Returning from a pre-calculated private attribute for performance improvements."""
         return self._row_count
@@ -213,11 +209,11 @@ class DataViewer(QWidget):
 
         self.label = QLabel()
         self.label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
-        self.table_view = QTableView()
-        self.table_view.hide()
+        self.data_view = QTableView()
+        self.data_view.hide()
 
         layout.addWidget(self.label)
-        layout.addWidget(self.table_view)
+        layout.addWidget(self.data_view)
 
         self.retranslateUI()
 
@@ -227,9 +223,9 @@ class DataViewer(QWidget):
         When a tabular file is selected, the main application will create a
         FrictionlessTableModel and call this function using the model as a parametner.
         """
-        self.table_view.setModel(model)
+        self.data_view.setModel(model)
         self.label.hide()
-        self.table_view.show()
+        self.data_view.show()
 
     def clear(self, model):
         """Reset the view to the default state.
@@ -237,9 +233,9 @@ class DataViewer(QWidget):
         This view depends of the main application self.table_model attribute. This
         method should always receive an empty model
         """
-        self.table_view.setModel(model)
+        self.data_view.setModel(model)
         self.label.show()
-        self.table_view.hide()
+        self.data_view.hide()
 
     def retranslateUI(self):
         """Apply translations to class elements."""

--- a/ode/panels/errors.py
+++ b/ode/panels/errors.py
@@ -27,11 +27,13 @@ class ErrorFilterProxyModel(QSortFilterProxyModel):
             [..., (row_number, error_type, error_message), ...]
         """
         source_model = self.sourceModel()
-        error = source_model.errors[source_row]
-        if not error:
+        if source_model.errors[source_row] is None or len(source_model.errors[source_row]) == 0:
             return False
-        if error[1] == self.error_type:
-            return True
+
+        for error in source_model.errors[source_row]:
+            if error[1] == self.error_type:
+                return True
+
         return False
 
 

--- a/ode/panels/errors.py
+++ b/ode/panels/errors.py
@@ -38,16 +38,11 @@ class ErrorFilterProxyModel(QSortFilterProxyModel):
         return False
 
     def data(self, index, role):
-        """Returns information to be used to render the Data Table View.
-
-        For each cell we return:
-         - The value to be displayed in the cell
-         - If there is an error in that cell, a red color for the Background.
-         - If there is an error in that cell, a message for the tooltip.
-        """
+        """Overrides the data method to set the background color of the cells according the error type."""
         if not index.isValid():
             return None
 
+        # Converts the index to the source model so we can map it with the errors list
         source_index = self.mapToSource(index)
         source_row = source_index.row()
         source_column = source_index.column()
@@ -56,6 +51,7 @@ class ErrorFilterProxyModel(QSortFilterProxyModel):
             source_model = self.sourceModel()
 
             if source_model.errors[source_row] is None or len(source_model.errors[source_row]) == 0:
+                # Default color
                 return None
 
             for error in source_model.errors[source_row]:
@@ -65,6 +61,7 @@ class ErrorFilterProxyModel(QSortFilterProxyModel):
                 elif error[0] == source_column and error[1] == self.error_type:
                     return QColor("red")
 
+            # Default color
             return None
 
         return super().data(index, role)

--- a/tests/ode/test_application.py
+++ b/tests/ode/test_application.py
@@ -1,5 +1,9 @@
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor
+
+
 def test_file_is_displayed(qtbot, window, project_folder):
-    p1 = (project_folder / "example.csv")
+    p1 = project_folder / "example.csv"
     p1.write_text("name,age\nAlice,30\nBob,25")
 
     # Assert Welcome screen is selected by default.
@@ -20,7 +24,7 @@ def test_file_is_displayed(qtbot, window, project_folder):
 
 
 def test_button_errors_displays_error_count(qtbot, window, project_folder):
-    p1 = (project_folder / "missing-header.csv")
+    p1 = project_folder / "missing-header.csv"
     p1.write_text("name,\nAlice,30\nBob,25")
 
     # Simulate click event
@@ -33,3 +37,75 @@ def test_button_errors_displays_error_count(qtbot, window, project_folder):
 
     # Test Frictionless error
     assert "Label should be provided and not be blank." in str(error_text)
+
+
+def test_error_reports_show_two_blank_lines_in_red(qtbot, window, project_folder):
+    """Test that two blank lines are shown in red in the error report."""
+    p1 = project_folder / "two-blank-lines.csv"
+    p1.write_text("name,surname\n,\n,")
+
+    # Simulate click event
+    index = window.sidebar.file_model.index(str(p1))
+    window.on_tree_click(index)
+
+    qtbot.waitUntil(lambda: window.content.toolbar.button_errors.error_label.text() == "2")
+    # Get error report
+    error_report = window.content.errors_view.reports_layout.takeAt(0)
+
+    proxy = error_report.widget().proxy_model
+    total_rows = proxy.rowCount()
+    red_rows = 0
+    red_background = QColor("red").name()
+
+    for row in range(total_rows):
+        # Get the proxy index for this row
+        index = proxy.index(row, 0)
+
+        # Get background color
+        background_color = proxy.data(index, Qt.BackgroundRole)
+
+        # If the color is red, increment counter
+        if background_color is not None and background_color.name() == red_background:
+            red_rows += 1
+
+    assert red_rows == 2
+
+
+def test_error_reports_show_two_errors_in_same_row(qtbot, window, project_folder):
+    """
+    This test is for the case where there are two errors in the same row, and
+    both errors are shown in red.
+
+    Error 1: Duplicated header
+    Error 2: Empty header
+    """
+    p1 = project_folder / "header-errors.csv"
+    p1.write_text("name,name,,empty\nname,surname,empty,empty")
+
+    # Simulate click event
+    index = window.sidebar.file_model.index(str(p1))
+    window.on_tree_click(index)
+
+    qtbot.waitUntil(lambda: window.content.toolbar.button_errors.error_label.text() == "2")
+
+    red_background = QColor("red").name()
+
+    # Check that we have two error report tables
+    assert window.content.errors_view.reports_layout.count() == 2
+
+    # Check we have on error in each report
+    # Error 1: Duplicated header
+    proxy_model = window.content.errors_view.reports_layout.itemAt(0).widget().proxy_model
+    assert proxy_model.error_type == "duplicate-label"
+    # Check the exact column
+    index = proxy_model.index(0, 1)
+    background_color = proxy_model.data(index, Qt.BackgroundRole)
+    assert background_color.name() == red_background
+
+    # Error 2: Empty header
+    proxy_model = window.content.errors_view.reports_layout.itemAt(1).widget().proxy_model
+    assert proxy_model.error_type == "blank-label"
+    # Check the exact column
+    index = proxy_model.index(0, 2)
+    background_color = proxy_model.data(index, Qt.BackgroundRole)
+    assert background_color.name() == red_background


### PR DESCRIPTION
- Fixes #772 
- Allows to have multiple errors in the same row
- Overrides the `data` method in the Errors report able to show for each table the error style corresponding
