### PR TITLE
Return content if properly read.

### DIFF
--- a/ode/panels/source.py
+++ b/ode/panels/source.py
@@ -26,7 +26,7 @@ class SourceViewer(QWidget):
         self.label = QLabel()
         self.label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
 
-        self.text_edit = QPlainTextEdit(self)
+        self.text_edit = QPlainTextEdit()
         self.text_edit.setLineWrapMode(QPlainTextEdit.NoWrap)
         self.text_edit.setReadOnly(True)
         self.text_edit.setFont(QFont("Courier, monospace"))
@@ -34,6 +34,30 @@ class SourceViewer(QWidget):
 
         layout.addWidget(self.label)
         layout.addWidget(self.text_edit)
+
+    def _read_file(self, filepath):
+        """Function to read the file from disk and return a string.
+
+        We could implement a more fancy approach with chardet to detect the file encoding
+        but early tests where not performat enough. We are brute-forcing the two most popular
+        encodings in the web.
+        """
+        content = ""
+        try:
+            with open(filepath, "r", encoding="utf-8") as file:
+                content = file.read()
+            return content
+        except Exception as e:
+            content = f"Error while reading the file with encoding UTF-8: {e}"
+
+        try:
+            with open(filepath, "r", encoding="iso-8859-1") as file:
+                content = file.read()
+            return content
+        except Exception as e:
+            content += f"\nError while reading the file with encoding ISO-8859-1: {e}"
+
+        return content
 
     def open_file(self, filepath):
         """Reads the file and sets the QPlainText."""
@@ -43,18 +67,7 @@ class SourceViewer(QWidget):
             self.text_edit.hide()
             return
 
-        content = ""
-        try:
-            with open(filepath, "r", encoding="utf-8") as file:
-                content = file.read()
-        except Exception as e:
-            content = f"Error while reading the file: {e}"
-
-        try:
-            with open(filepath, "r", encoding="iso-8859-1") as file:
-                content = file.read()
-        except Exception as e:
-            content += f"\nError while reading the file: {e}"
+        content = self._read_file(filepath)
 
         self.label.hide()
         self.text_edit.show()


### PR DESCRIPTION
Fixes #782 

The data viewer was working properly but I detected a small issue in the `Source` panel that was not properly reading/displaying `utf-8` encoding characters. The problem was that the current logic was not exiting as soon as it was able to read the file and re-reading it with a wrong encoding.


### From:
![image](https://github.com/user-attachments/assets/fc8d91cd-6610-4a6b-9c5f-a0dadfe7d2ee)
![image](https://github.com/user-attachments/assets/f4299aee-b8c0-48f3-bbd1-c30861a9ef18)

### To:
![image](https://github.com/user-attachments/assets/fc8d91cd-6610-4a6b-9c5f-a0dadfe7d2ee)
![image](https://github.com/user-attachments/assets/8ee12957-09ef-45ae-8505-d2f28b0f92ce)


---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
