### PR TITLE
Run packaging only on merges and tags.

### DIFF
--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -57,6 +57,7 @@ jobs:
         run: |
             pytest
   macos-packaging:
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/tags/v*.*.*'
     needs: tests
     runs-on: macos-13
     steps:
@@ -89,6 +90,7 @@ jobs:
             *.dmg
           retention-days: 14
   linux-packaging:
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/tags/v*.*.*'
     needs: tests
     runs-on: ubuntu-22.04
     steps:
@@ -125,6 +127,7 @@ jobs:
             dist/*.deb
           retention-days: 14
   windows-packaging:
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/tags/v*.*.*'
     needs: tests
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
We do not need to build everything on each commit so let's not waste resources and time.

We can comment these particular lines when debugging or developing the Packaging logic.