### PR TITLE
Install missing dependencies on Linux package builder

### DIFF
--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -110,7 +110,7 @@ jobs:
           # https://forum.qt.io/post/769050
           # Fix PyInstaller warnings of Qt Dependencies missing
           sudo apt-get install synaptic
-          sudo apt-get install libxcb-icccm4 libxcb-image0-dev libxcb-keysyms1 libxcb-render-util0 libxcb-xkb1 libxcb-xinerama0 libxkbcommon-x11-0
+          sudo apt-get install libxcb-icccm4 libxcb-image0-dev libxcb-keysyms1 libxcb-render-util0 libxcb-xkb1 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0
           sudo apt-get install qt6-qpa-plugins
 
       - name: Install Dependencies

--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -90,7 +90,7 @@ jobs:
             *.dmg
           retention-days: 14
   linux-packaging:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/tags/v*.*.*'
+    # if: github.ref == 'refs/heads/main' || github.ref == 'refs/tags/v*.*.*'
     needs: tests
     runs-on: ubuntu-22.04
     steps:
@@ -111,6 +111,8 @@ jobs:
           # Fix PyInstaller warnings of Qt Dependencies missing
           sudo apt-get install synaptic
           sudo apt-get install libxcb-icccm4 libxcb-image0-dev libxcb-keysyms1 libxcb-render-util0 libxcb-xkb1 libxcb-xinerama0 libxkbcommon-x11-0
+          sudo apt-get install qt6-qpa-plugins
+
       - name: Install Dependencies
         run: |
           pip3 install -r requirements.txt

--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -110,8 +110,7 @@ jobs:
           # https://forum.qt.io/post/769050
           # Fix PyInstaller warnings of Qt Dependencies missing
           sudo apt-get install synaptic
-          sudo apt-get install libxcb-icccm4 libxcb-image0-dev libxcb-keysyms1 libxcb-render-util0 libxcb-xkb1 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0
-          sudo apt-get install qt6-qpa-plugins
+          sudo apt-get install libxcb-icccm4 libxcb-image0-dev libxcb-keysyms1 libxcb-render-util0 libxcb-xkb1 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0 libxcb-shape0-dev
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -90,7 +90,7 @@ jobs:
             *.dmg
           retention-days: 14
   linux-packaging:
-    # if: github.ref == 'refs/heads/main' || github.ref == 'refs/tags/v*.*.*'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/tags/v*.*.*'
     needs: tests
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
- fixes #884 

I'm adding two missing dependencies (`libxcb-cursor0 libxcb-shape0-dev`) to our builder to fix 2 warnings that are causing errors when running in Ubuntu and another Debian based distributions.:
```
66485 WARNING: Library not found: could not resolve 'libxcb-cursor.so.0', dependency of '/opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/PySide6/Qt/plugins/xcbglintegrations/libqxcb-glx-integration.so'.
66485 WARNING: Library not found: could not resolve 'libxcb-shape.so.0', dependency of '/opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/PySide6/Qt/plugins/xcbglintegrations/libqxcb-glx-integration.so'.
```
---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
