### PR TITLE
Fix GitHub actions condition

### DIFF
--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -57,7 +57,7 @@ jobs:
         run: |
             pytest
   macos-packaging:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/tags/v*.*.*'
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     needs: tests
     runs-on: macos-13
     steps:
@@ -90,7 +90,7 @@ jobs:
             *.dmg
           retention-days: 14
   linux-packaging:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/tags/v*.*.*'
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     needs: tests
     runs-on: ubuntu-22.04
     steps:
@@ -128,7 +128,7 @@ jobs:
             dist/*.deb
           retention-days: 14
   windows-packaging:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/tags/v*.*.*'
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     needs: tests
     runs-on: windows-latest
     steps:
@@ -159,7 +159,7 @@ jobs:
             .\packaging\windows\*.exe
           retention-days: 14
   linux-app-image:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/tags/v*.*.*'
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     needs: tests
     runs-on: ubuntu-22.04
     steps:

--- a/ode/__init__.py
+++ b/ode/__init__.py
@@ -1,3 +1,3 @@
 # ODE Module was created for PyInstaller to collect all assets of the project properly
 
-__version__ = "1.4.0"
+__version__ = "1.4.2"


### PR DESCRIPTION
This PR fixes:
 - The Github actions condition to run on tags creation
 - It bumps the version to `v1.4.2` to fix the missing version number on `v1.4.1`