### PR TITLE
Add Release action

### DIFF
--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -191,4 +191,23 @@ jobs:
           path: |
             dist/*.AppImage
           retention-days: 14
+  release:
+    runs-on: ubuntu-latest
+    needs: [macos-packaging, windows-packaging, linux-packaging, linux-app-image]
+    if: github.ref_type == 'tag'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Create release and upload assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            artifacts/*.exe
+            artifacts/*.dmg
+            artifacts/*.deb
+            artifacts/*.AppImage
+          draft: true
+          overwrite_files: false
 


### PR DESCRIPTION
This is a small PR to try to automate the Github Release when creating a new `tag`.

Ideally I would like a Draft Release to be cretated and Artifacts uploaded to avoid this manual step.

### Technical Notes

I have been testing similar approaches, here are some challenges:
 - Github Actions uploads artifacts on ZIP files (we cannot access to the executables)
 - [Github Release Action](https://github.com/softprops/action-gh-release) allow us to upload executables without zipping but it is per job.