### PR TITLE
Use splitter for main layout

### DIFF
--- a/ode/main.py
+++ b/ode/main.py
@@ -9,7 +9,6 @@ from PySide6.QtWidgets import (
     QApplication,
     QMainWindow,
     QWidget,
-    QGridLayout,
     QVBoxLayout,
     QHBoxLayout,
     QTreeView,


### PR DESCRIPTION
Fixes #923, depends on #986

This PR removes the fixed width of the Sidebar and add a QSplitter widget to allow users to resize the area.

When developing this feature I found a bug in the way we are handling changes in the cursor that leaves the application's cursor in a buggy state. It will be handled in a separated PR.