### PR TITLE
Refactor and Simplify the behavior of the first row.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ pytest
 pytest-qt
 mypy
 ruff
+ipdb

--- a/ode/panels/data.py
+++ b/ode/panels/data.py
@@ -14,7 +14,7 @@ from openpyxl.styles import PatternFill
 from ode import utils
 from ode.dialogs.metadata import ColumnMetadataDialog, ColumnMetadataField
 from ode.file import File
-from ode.shared import COLOR_RED
+from ode.shared import COLOR_RED, COLOR_BLUE
 from ode.paths import Paths
 
 
@@ -102,7 +102,7 @@ class ColumnMetadataIconDelegate(QStyledItemDelegate):
         """Paint the icon in the first row of the table adds blue background if mouse over."""
         if index.row() == 0:
             if option.state & QStyle.State_MouseOver:
-                painter.fillRect(option.rect, option.palette.highlight().color().lighter(160))
+                painter.fillRect(option.rect, COLOR_BLUE)
             self.icon.paint(painter, self._get_icon_rect(option))
         super().paint(painter, option, index)
 

--- a/ode/shared.py
+++ b/ode/shared.py
@@ -1,3 +1,4 @@
 from PySide6.QtGui import QColor
 
 COLOR_RED = QColor("#D32F2F")
+COLOR_BLUE = QColor("#0288D1")


### PR DESCRIPTION
When working on #985 I discovered a small bug that was created by the way we were handling the changes in the cursor when the user is hovering the first row.

Current Behaviour:
 - When hovering the icon we change the icon.
 - When clicking on the icon we open the dialog.
 - When double clicking on the cell we open the dialog. (Default Cell edit for first row is no longer available)

It makes no sense (and makes the code more dirty) to have this two behaviours so I'm proposing to:
 - When hovering the cells in the first row we change the mouse pointer.
 - When clicking on the cells in the first row we open the dialog.

[simplescreenrecorder-2025-08-06_11.55.53.webm](https://github.com/user-attachments/assets/75b2f01b-bf35-4dcb-a91d-dd096b1d6bf3)
