### PR TITLE
Fix AI dialog sizes

### DIFF
--- a/ode/dialogs/llm_dialog_warning.py
+++ b/ode/dialogs/llm_dialog_warning.py
@@ -9,14 +9,15 @@ class LLMWarningDialog(QDialog):
 
     def __init__(self, parent: QWidget):
         super().__init__(parent)
-
-        self.result_text = None
-        layout = QVBoxLayout()
         self.setWindowTitle(self.tr("AI feature"))
+        # TODO: dialog size is not set properly when having the application in a second monitor
+        # so we force it to a minimun.
+        self.setMinimumSize(500, 200)
+
+        layout = QVBoxLayout()
 
         self.warning_text = QLabel()
         self.warning_text.setWordWrap(True)
-        layout.addWidget(self.warning_text)
         self.warning_text.setText(
             self.tr(
                 "The AI integration operates entirely on your laptop. This means that when using this feature the data from your table is never sent or shared outside this device."
@@ -35,6 +36,7 @@ class LLMWarningDialog(QDialog):
         self.ok_button.clicked.connect(self.accept)
         self.ok_button.setText(self.tr("Ok"))
 
+        layout.addWidget(self.warning_text)
         layout.addLayout(button_layout)
         self.setLayout(layout)
 

--- a/ode/llama.py
+++ b/ode/llama.py
@@ -200,28 +200,20 @@ class LlamaDownloadDialog(QDialog):
     def init_ui(self):
         """Initialize the UI for the Llama download dialog."""
         self.setWindowTitle(self.tr("AI feature"))
-        self.setMinimumSize(500, 400)
+
         layout = QVBoxLayout(self)
 
-        # Models List Section
         label_models = QLabel(self.tr("To start using the AI feature, please select one of the following models."))
         layout.addWidget(label_models)
 
-        download_location_box = QHBoxLayout()
-
-        label_download_location_text = QLabel(self.tr("The ODE will save the file in this location:"))
-        download_location_box.addWidget(label_download_location_text)
-
         label_download_location = QLabel(
-            f'<i><a href="file://{AI_MODELS_PATH}" style="color: blue; text-decoration: underline;">{AI_MODELS_PATH}</a></i>'
+            self.tr(f'The ODE will save the file in this location: <i><a href="file://{AI_MODELS_PATH}">{AI_MODELS_PATH}</a></i>')
         )
         label_download_location.setTextFormat(Qt.RichText)
         label_download_location.setTextInteractionFlags(Qt.TextBrowserInteraction)
-        label_download_location.setTextInteractionFlags(Qt.TextBrowserInteraction)
         label_download_location.linkActivated.connect(self.open_download_directory)
 
-        download_location_box.addWidget(label_download_location)
-        layout.addLayout(download_location_box)
+        layout.addWidget(label_download_location)
 
         self.model_list = QListWidget()
         self.model_list.setMinimumHeight(200)


### PR DESCRIPTION
For some reason when working with multiple monitors we are having a problem with the size of the dialogs. The following are screenshots of how dialogs are being shown when displaying ODE in a monitor that it is connected to the laptop using HDMI.

I'm not sure if this is the correct fix but it will do it *for now<sup>TM</sup>*

The warning dialog is too small:
<img width="241" height="206" alt="image" src="https://github.com/user-attachments/assets/b8c9f2cc-a581-46ca-9e2d-ae9a9025fbcd" />

The download dialog do not show the complete link:
<img width="530" height="455" alt="image" src="https://github.com/user-attachments/assets/ddc89f9e-d08b-40bb-b356-c9bf692787ed" />

There must be some hidden reason related to parents and monitors DPIs so this quick fix will do it.