### PR TITLE
Manually collect llama_cpp and numpy imports.

### DIFF
--- a/build.py
+++ b/build.py
@@ -24,7 +24,7 @@ def build_application():
         "--collect-all", "frictionless",  # Frictionless depends on data files
         "--collect-all", "ode",  # Collect all assets from Open Data Editor
         "--collect-all", "llama_cpp", # Collect all assets from llama_cpp
-        "--collect-all", "numpy", # Collect all assets from numpy (llama_cpp dependency)
+        "--collect-all", "numpy",  # Collect all assets from numpy (llama_cpp dependency)
         "--log-level",
         "WARN",
         "--name",


### PR DESCRIPTION
Installed versions of the application are failing due to missing dependencies:
```
FileNotFoundError: Shared library with base name 'llama' not found
[PYI-5344:ERROR] Failed to execute script 'main' due to unhandled exception: Shared library with base name 'llama' not found
[PYI-5344:ERROR] Traceback:
Traceback (most recent call last):
  File "ode/main.py", line 63, in <module>
    from ode.llama import LlamaDialog, LlamaDownloadDialog
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "PyInstaller/loader/pyimod02_importers.py", line 384, in exec_module
  File "ode/llama.py", line 7, in <module>
    from llama_cpp import Llama as LlamaCPP
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "PyInstaller/loader/pyimod02_importers.py", line 384, in exec_module
  File "llama_cpp/__init__.py", line 1, in <module>
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "PyInstaller/loader/pyimod02_importers.py", line 384, in exec_module
  File "llama_cpp/llama_cpp.py", line 38, in <module>
  File "llama_cpp/_ctypes_extensions.py", line 71, in load_shared_library
FileNotFoundError: Shared library with base name 'llama' not found
```

In order to fix it we need to manually collect `llama_cpp` and `numpy` to ensure all modules are compiled.
