### PR TITLE
Allow the user to change between excel sheets if they exists

### DIFF
--- a/ode/assets/style.qss
+++ b/ode/assets/style.qss
@@ -67,6 +67,13 @@ Toolbar QPushButton[active="true"]{
   outline: none;
 }
 
+Toolbar QComboBox#excelSheetCombo,
+Toolbar QLabel#excelSheetLabel {
+  font-size: 16px;
+  font-weight: 600;
+  color: #4C5564;
+}
+
 QPushButton#button_save, QPushButton#button_export, QPushButton#button_ai {
   font-size: 14px;
   font-weight: 500;

--- a/ode/file.py
+++ b/ode/file.py
@@ -97,11 +97,12 @@ class File:
         return metadata
 
     def _setup_metadata_first_time(self, sheet_name: str | None = None):
-        print("Setting up metadata for", sheet_name)
+        """
+        Set up the metadata for the first time when the file is opened.
+        """
         metadata = dict()
         self.metadata_path.parent.mkdir(parents=True, exist_ok=True)
         with system.use_context(trusted=True):
-            print(sheet_name)
             if sheet_name:
                 resource = TableResource(self.path, control=ExcelControl(sheet=sheet_name))
             else:

--- a/ode/file.py
+++ b/ode/file.py
@@ -77,6 +77,7 @@ class File:
 
             with system.use_context(trusted=True):
                 if sheet_name:
+                    print("Using existing metadata for", sheet_name)
                     resource = TableResource(metadata["resource"], control=ExcelControl(sheet=sheet_name))
                 else:
                     resource = TableResource(metadata["resource"])

--- a/ode/file.py
+++ b/ode/file.py
@@ -1,5 +1,6 @@
 import json
 import shutil
+import logging
 
 from frictionless import system
 from frictionless.resources import TableResource
@@ -7,6 +8,8 @@ from frictionless.formats.excel import ExcelControl
 from pathlib import Path
 
 from ode import paths
+
+logger = logging.getLogger(__name__)
 
 
 class File:
@@ -68,8 +71,10 @@ class File:
         return metadata_path / (self.path.stem + ".json")
 
     def get_or_create_metadata(self, sheet_name: str | None = None):
-        """Get or create a metadata object for the Resource."""
+        """Get or create a metadata object for the Resource.
 
+        Sheet name is used to specify which sheet of the Excel file we want to use.
+        """
         if self.metadata_path.exists():
             metadata = dict()
             with open(self.metadata_path) as file:
@@ -77,9 +82,10 @@ class File:
 
             with system.use_context(trusted=True):
                 if sheet_name:
-                    print("Using existing metadata for", sheet_name)
+                    logger.info("Using sheet %s for resource %s", sheet_name, self.path)
                     resource = TableResource(metadata["resource"], control=ExcelControl(sheet=sheet_name))
                 else:
+                    logger.info("Using resource %s", self.path)
                     resource = TableResource(metadata["resource"])
 
                 resource.infer()

--- a/ode/file.py
+++ b/ode/file.py
@@ -66,7 +66,7 @@ class File:
 
         return metadata_path / (self.path.stem + ".json")
 
-    def get_or_create_metadata(self):
+    def get_or_create_metadata(self, sheet_name: str | None = None):
         """Get or create a metadata object for the Resource."""
         metadata = dict()
 

--- a/ode/file.py
+++ b/ode/file.py
@@ -71,17 +71,14 @@ class File:
         """Get or create a metadata object for the Resource."""
 
         if self.metadata_path.exists():
-            print("Getting or creating metadata for", sheet_name)
             metadata = dict()
             with open(self.metadata_path) as file:
                 metadata = json.load(file)
 
             with system.use_context(trusted=True):
                 if sheet_name:
-                    print("hola")
                     resource = TableResource(metadata["resource"], control=ExcelControl(sheet=sheet_name))
                 else:
-                    print("chau")
                     resource = TableResource(metadata["resource"])
 
                 resource.infer()

--- a/ode/main.py
+++ b/ode/main.py
@@ -963,7 +963,6 @@ class MainWindow(QMainWindow):
             self.content.toolbar.excel_sheet_container.setVisible(False)
             self.excel_sheet_name = None
 
-        print("Sheet name", self.excel_sheet_name)
         self.content.toolbar.excel_sheet_combo.blockSignals(False)
 
     def on_excel_sheet_selection_changed(self, sheet_name: str):

--- a/ode/main.py
+++ b/ode/main.py
@@ -450,8 +450,17 @@ class Toolbar(QWidget):
         layout.addWidget(self.button_errors)
         layout.addWidget(self.button_source)
 
+        self.excel_sheet_layout = QHBoxLayout()
+        self.excel_sheet_container = QWidget()
+        self.excel_sheet_label = QLabel(self.tr("Excel Sheet:"))
         self.excel_sheet_combo = QComboBox()
-        layout.addWidget(self.excel_sheet_combo)
+
+        self.excel_sheet_layout.addWidget(self.excel_sheet_label)
+        self.excel_sheet_layout.addWidget(self.excel_sheet_combo)
+
+        self.excel_sheet_container.setLayout(self.excel_sheet_layout)
+
+        layout.addWidget(self.excel_sheet_container)
 
         # Spacer to push right-side buttons to the end
         layout.addStretch()
@@ -941,10 +950,12 @@ class MainWindow(QMainWindow):
             # sheet_names.sort()  # Sort the sheet names alphabetically
             if self.excel_sheet_name is None:
                 self.excel_sheet_name = sheet_names[0]
+
             self.content.toolbar.excel_sheet_combo.addItems(sheet_names)
             self.content.toolbar.excel_sheet_combo.setCurrentText(self.excel_sheet_name)
+            self.content.toolbar.excel_sheet_container.setVisible(True)
         else:
-            # TODO: Seleccionar uno
+            self.content.toolbar.excel_sheet_container.setVisible(False)
             self.excel_sheet_name = None
 
         print("Sheet name", self.excel_sheet_name)

--- a/ode/main.py
+++ b/ode/main.py
@@ -450,6 +450,7 @@ class Toolbar(QWidget):
         layout.addWidget(self.button_errors)
         layout.addWidget(self.button_source)
 
+        # Excel Sheet Selection
         self.excel_sheet_layout = QHBoxLayout()
         self.excel_sheet_container = QWidget()
         self.excel_sheet_label = QLabel(self.tr("Excel Sheet:"))
@@ -940,6 +941,10 @@ class MainWindow(QMainWindow):
         return sheet_names
 
     def update_excel_sheet_dropdown(self, filepath):
+        """
+        Update the Excel sheet dropdown with the names of the sheets in the selected file.
+        If there are no sheets, the dropdown and label will be hidden.
+        """
         self.content.toolbar.excel_sheet_combo.blockSignals(True)
 
         self.content.toolbar.excel_sheet_combo.clear()
@@ -947,7 +952,6 @@ class MainWindow(QMainWindow):
         sheet_names = self.get_sheets_names(filepath)
 
         if sheet_names:
-            # sheet_names.sort()  # Sort the sheet names alphabetically
             if self.excel_sheet_name is None:
                 self.excel_sheet_name = sheet_names[0]
 
@@ -962,9 +966,11 @@ class MainWindow(QMainWindow):
         self.content.toolbar.excel_sheet_combo.blockSignals(False)
 
     def on_excel_sheet_selection_changed(self, sheet_name: str):
-        """Handle the change of the selected Excel sheet in the dropdown."""
+        """
+        Handle the change of the selected Excel sheet in the dropdown.
+        Reloads the file with the selected sheet name and updates the views.
+        """
         if self.selected_file_path.suffix in [".xls", ".xlsx"]:
-            print("Selected sheet name:", sheet_name)
             self.excel_sheet_name = sheet_name
             self.read_validate_and_display_file(self.selected_file_path)
         else:

--- a/ode/main.py
+++ b/ode/main.py
@@ -453,8 +453,11 @@ class Toolbar(QWidget):
         # Excel Sheet Selection
         self.excel_sheet_layout = QHBoxLayout()
         self.excel_sheet_container = QWidget()
-        self.excel_sheet_label = QLabel(self.tr("Excel Sheet:"))
+        self.excel_sheet_label = QLabel(self.tr("Sheet:"))
+        self.excel_sheet_label.setObjectName("excelSheetLabel")
+
         self.excel_sheet_combo = QComboBox()
+        self.excel_sheet_combo.setObjectName("excelSheetCombo")
 
         self.excel_sheet_layout.addWidget(self.excel_sheet_label)
         self.excel_sheet_layout.addWidget(self.excel_sheet_combo)
@@ -952,7 +955,7 @@ class MainWindow(QMainWindow):
 
         sheet_names = self.get_sheets_names(filepath)
 
-        if sheet_names:
+        if sheet_names and len(sheet_names) > 1:
             if self.excel_sheet_name is None:
                 self.excel_sheet_name = sheet_names[0]
 

--- a/ode/main.py
+++ b/ode/main.py
@@ -884,6 +884,7 @@ class MainWindow(QMainWindow):
             self.selected_file_path = path
             # Calling file_model.index() has a weird side-effect in the QTreeView that will display the new
             # uploaded file at the end of the list instead of the default alphabetical order.
+            self.excel_sheet_name = None
             index = self.sidebar.file_model.index(str(path))
             self.sidebar.file_navigator.selectionModel().select(index, QItemSelectionModel.SelectionFlag.ClearAndSelect)
             self.read_validate_and_display_file(path)

--- a/ode/panels/data.py
+++ b/ode/panels/data.py
@@ -498,7 +498,6 @@ class DataViewer(QWidget):
         self.table_view.horizontalHeader().setDefaultSectionSize(120)
         self.table_view.setMouseTracking(True)
 
-        # TODO: chequear
         self.metadata = File(filepath).get_or_create_metadata(sheet_name)
         self.resource = self.metadata.get("resource")
 

--- a/ode/panels/data.py
+++ b/ode/panels/data.py
@@ -181,11 +181,12 @@ class FrictionlessTableModel(QAbstractTableModel):
         wb = load_workbook(filepath)
 
         if sheet_name in wb.sheetnames:
-            wb.remove(wb[sheet_name])
-            logger.info(f"Removed existing sheet: {sheet_name}")
-
-        print(f"Creating new sheet: {sheet_name}")
-        ws = wb.create_sheet(sheet_name)
+            ws = wb[sheet_name]
+            logger.info(f"Deleting existing data in sheet: {sheet_name}")
+            ws.delete_rows(1, ws.max_row)  # Delete all rows
+        else:
+            logger.error(f"Sheet {sheet_name} does not exist in the workbook: {filepath}")
+            raise ValueError(f"Sheet {sheet_name} does not exist in the workbook: {filepath}")
 
         # Header row
         ws.append(self._data[0])

--- a/ode/panels/data.py
+++ b/ode/panels/data.py
@@ -22,6 +22,8 @@ from ode.file import File
 from ode.shared import COLOR_RED, COLOR_BLUE
 from ode.paths import Paths
 
+import xlrd
+
 
 DEFAULT_LIMIT_ERRORS = 1000
 
@@ -44,10 +46,11 @@ class DataWorker(QRunnable):
     the user.
     """
 
-    def __init__(self, filepath):
+    def __init__(self, filepath, sheet_name=None):
         super().__init__()
         self.file = File(filepath)
         self.signals = DataWorkerSignals()
+        self.sheet_name = sheet_name
         self.resource = self.file.get_or_create_metadata().get("resource")
 
     @Slot()


### PR DESCRIPTION
- Fixes #1000 
- If it’s an Excel file, a dropdown appears to switch between sheets.
- If it’s a CSV file, the dropdown is hidden.
- The user can export the current sheet with its errors.
- The user can modify and save each sheet separately.
- It doesn’t work with Google Spreadsheets, since they are saved as CSV.