### PR TITLE
Fix saving XLS files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ PySide6==6.9.1
 openai==1.61.1
 pytest==8.3.5
 llama_cpp_python==0.3.9
+xlutils==2.0.0
+xlrd==2.0.2
+xlwt==1.3.0


### PR DESCRIPTION
Saving XLS files is not working at the moment. They are being saved as XLSX, which later causes an error in Frictionless. This fixes this.