### PR TITLE
Handle exception when migrating from v1.3

### DIFF
--- a/ode/__init__.py
+++ b/ode/__init__.py
@@ -1,3 +1,3 @@
 # ODE Module was created for PyInstaller to collect all assets of the project properly
 
-__version__ = "1.6.1"
+__version__ = "1.6.2"

--- a/ode/utils.py
+++ b/ode/utils.py
@@ -53,7 +53,13 @@ def migrate_metadata_store():
 
     # ODE v1.3 has been used and we need to migrate.
     with open(metadata_file_path, "r") as file:
-        metadata = json.load(file)
+        try:
+            metadata = json.load(file)
+        except Exception as e:
+            # We are receiving json.decoder.JSONDecodeError error reports from users.
+            # So we skip the migration if the file cannot be read.
+            print(f"Cannot read ode v1.3 metadata file. Skipping migration: {e}")
+            return
 
     records = metadata["record"]
 


### PR DESCRIPTION
We are receiving errors reports of the application crashing when trying to load the old json file of Open Data Editor.

This could happen by corrupted files.

```
An unexpected error occurred: JSONDecodeError: Expecting value: line 1 column 1 (char 0)" followed by
"Traceback (most recent call last):
  File "ode\main.py", line 1162, in <module>
    migrate_metadata_store()
    ~~~~~~~~~~~~~~~~~~~~~~^^
  File "ode\utils.py", line 56, in migrate_metadata_store
    metadata = json.load(file)
  File "json\__init__.py", line 293, in load
  File "json\__init__.py", line 346, in loads
  File "json\decoder.py", line 345, in decode
  File "json\decoder.py", line 363, in raw_decode
json.decoder.JSONDecodeError: Expectin
```