### PR TITLE
Reset prompt when closing the AI dialog.

### DIFF
--- a/ode/llama.py
+++ b/ode/llama.py
@@ -110,6 +110,7 @@ class LlamaDialog(QDialog):
         if self.worker and self.worker.isRunning():
             self.worker.terminate()
             self.worker.wait()
+        self.prompt_selector.setCurrentIndex(0)
         self.output_text.clear()
         self.on_execution_finished()
         event.accept()


### PR DESCRIPTION
Just a small fix. When closing the AI widget the selected prompt is not set back to the initial value.

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
