### PR TITLE
Fix override of text when painting header row

### DIFF
--- a/ode/panels/data.py
+++ b/ode/panels/data.py
@@ -106,11 +106,11 @@ class ColumnMetadataIconDelegate(QStyledItemDelegate):
 
     def paint(self, painter, option, index):
         """Paint the icon in the first row of the table adds blue background if mouse over."""
-        super().paint(painter, option, index)
         if index.row() == 0:
             if option.state & QStyle.StateFlag.State_MouseOver:
                 painter.fillRect(option.rect, COLOR_BLUE)
             self.icon.paint(painter, self._get_icon_rect(option))
+        super().paint(painter, option, index)
 
     def editorEvent(self, event, model, option, index):
         """Handle mouse events for the first row."""


### PR DESCRIPTION
@rustico @romicolman I'm seeing a wrong rendering of the header row in which the blue background covers the text when hovering the header row. (Or the text is not being display)

The problem is that this PR is reverting a previous change: #1020 so I'm not sure what's going on. Can you replicate this on your end?

Before this PR:
<img width="521" height="263" alt="before" src="https://github.com/user-attachments/assets/6fd713e6-fcae-4b7b-af76-217c42d46baa" />

After this PR:
<img width="459" height="271" alt="after" src="https://github.com/user-attachments/assets/b14c0eee-b717-4313-8311-4c8338cb00d6" />

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
