### PR TITLE
UX: Add explicit feedback when file has no errors

### DIFF
--- a/src/ode/assets/style.qss
+++ b/src/ode/assets/style.qss
@@ -45,6 +45,11 @@ ErrorsReportButton QLabel[error="true"] {
   color: #D32F2F;
   padding: 0px;
 }
+ErrorsReportButton QLabel[no_errors="true"] {
+  border: 1px solid #A5D6A7;
+  color: #2E7D32;
+  padding: 0px;
+}
 
 Toolbar QPushButton {
   font-size: 16px;

--- a/src/ode/main.py
+++ b/src/ode/main.py
@@ -410,10 +410,23 @@ class ErrorsReportButton(QPushButton):
         self.icon_label.setEnabled(True)
         self.text_label.setEnabled(True)
         self.error_label.setEnabled(True)
+        self.error_label.setProperty("no_errors", False)
+        self.error_label.style().polish(self.error_label)
         if number <= 999:
             self.error_label.setText(str(number))
         else:
             self.error_label.setText("+999")
+        self.error_label.show()
+        self.updateGeometry()
+    
+    def enable_no_errors(self):
+        self.setEnabled(True)
+        self.icon_label.setEnabled(True)
+        self.text_label.setEnabled(True)
+        self.error_label.setEnabled(True)
+        self.error_label.setProperty("no_errors", True)
+        self.error_label.style().polish(self.error_label)
+        self.error_label.setText("0")
         self.error_label.show()
         self.updateGeometry()
 
@@ -767,7 +780,7 @@ class MainWindow(QMainWindow):
         """Handle the click on the Export button."""
         # TODO: we are using a proxy variable to check if the file has errors. We should find a
         # better state variable for it.
-        has_errors = self.content.toolbar.button_errors.isEnabled()
+        has_errors = self.content.toolbar.button_errors.error_label.property("no_errors") is False and self.content.toolbar.button_errors.isEnabled()
         download_dialog = DownloadDialog(self, self.selected_file_path, has_errors)
         download_dialog.download_data_with_errors.connect(self.on_download_error_file)
         download_dialog.show()
@@ -1028,7 +1041,7 @@ class MainWindow(QMainWindow):
 
         # If we don't have errors we don't enable the Errors Report tab.
         if errors_count == 0:
-            self.content.toolbar.button_errors.disable()
+            self.content.toolbar.button_errors.enable_no_errors()
         else:
             self.content.toolbar.button_errors.enable(errors_count)
 

--- a/src/ode/panels/errors.py
+++ b/src/ode/panels/errors.py
@@ -156,7 +156,7 @@ class ErrorsWidget(QWidget):
 
         self.no_errors_label = QLabel()
         self.no_errors_label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
-        self.no_errors_label.setStyleSheet("font-size: 17px; color: #2E7D32;")
+        self.no_errors_label.setStyleSheet("font-size: 17px;")
         self.no_errors_label.hide()
          
         self.max_errors_label = QLabel()

--- a/src/ode/panels/errors.py
+++ b/src/ode/panels/errors.py
@@ -154,6 +154,11 @@ class ErrorsWidget(QWidget):
         super().__init__(*args, **kwargs)
         layout = QVBoxLayout()
 
+        self.no_errors_label = QLabel()
+        self.no_errors_label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
+        self.no_errors_label.setStyleSheet("font-size: 17px; color: #2E7D32;")
+        self.no_errors_label.hide()
+         
         self.max_errors_label = QLabel()
         font = QFont()
         font.setItalic(True)
@@ -166,6 +171,7 @@ class ErrorsWidget(QWidget):
         self.reports_layout.setContentsMargins(0, 0, 0, 0)
         self.reports.setLayout(self.reports_layout)
 
+        layout.addWidget(self.no_errors_label)
         layout.addWidget(self.max_errors_label)
         layout.addWidget(self.reports)
 
@@ -180,7 +186,9 @@ class ErrorsWidget(QWidget):
         """
         self.clear()
         if not errors:
+            self.no_errors_label.show()
             return
+        self.no_errors_label.hide()
 
         errors_list = self._sort_frictionless_errors(errors)
         total_errors = 0
@@ -201,6 +209,7 @@ class ErrorsWidget(QWidget):
             errorReport = self.reports_layout.takeAt(0)
             errorReport.widget().deleteLater()
         self.reports.hide()
+        self.no_errors_label.hide()
 
     def _sort_frictionless_errors(self, errors):
         """Splits a list of dictionaries into several lists grouped by type.
@@ -215,6 +224,7 @@ class ErrorsWidget(QWidget):
         return list(result.values())
 
     def retranslateUI(self):
+        self.no_errors_label.setText(self.tr("The file has been processed and no errors have been found."))
         self.max_errors_label.setText(
             self.tr("Please note that the ODE currently detects errors in tables, with a maximum of ")
             + str(DEFAULT_LIMIT_ERRORS)


### PR DESCRIPTION
- Fixes #1077 

---

When a file is processed and has no errors, the Errors Report button was previously disabled with no explanation, which confused first-time users (reported in #1077).

This PR implements the UX improvement suggested by @pdelboca. 

  - The Errors Report button is now always enabled after a file is loaded
  - A green "0" badge is shown on the button when no errors are found
  - The Errors panel displays a clear message: "The file has been
    processed and no errors have been found."

This follows the same approach used to fix the Source View button
confusion in #1023.

**Note:** Unable to run tests locally due to hardware limitations (llama-cpp-python                                                                         requires more RAM than available). Please verify via CI.
